### PR TITLE
fix: use explicit .js extensions for ESM-compliant imports

### DIFF
--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -22,9 +22,9 @@ import {
     LoroTreeSchema,
     RootSchemaType,
     SchemaType,
-} from "../schema";
-import { ChangeKinds, InferContainerOptions, type Change } from "./mirror";
-import { CID_KEY } from "../constants";
+} from "../schema/index.js";
+import { ChangeKinds, InferContainerOptions, type Change } from "./mirror.js";
+import { CID_KEY } from "../constants.js";
 
 import {
     containerIdToContainerType,
@@ -42,7 +42,7 @@ import {
     isArrayLike,
     isTreeID,
     defineCidProperty,
-} from "./utils";
+} from "./utils.js";
 
 /**
  * Finds the longest increasing subsequence of a sequence of numbers

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -2,11 +2,11 @@
  * Core mirroring functionality for syncing application state with Loro CRDT
  */
 
-export { Mirror, SyncDirection, toNormalizedJson } from "./mirror";
+export { Mirror, SyncDirection, toNormalizedJson } from "./mirror.js";
 export type {
     InferContainerOptions,
     MirrorOptions,
     SetStateOptions,
     SubscriberCallback,
     UpdateMetadata,
-} from "./mirror";
+} from "./mirror.js";

--- a/packages/core/src/core/loroEventApply.test.ts
+++ b/packages/core/src/core/loroEventApply.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable unicorn/consistent-function-scoping */
 import { describe, it, expect } from "vitest";
 import { LoroDoc, LoroText, LoroList, LoroMap, LoroCounter } from "loro-crdt";
-import { applyEventBatchToState } from "./loroEventApply";
+import { applyEventBatchToState } from "./loroEventApply.js";
 
 const commitAndAssert = (doc: LoroDoc, getState: () => unknown) => {
     doc.commit();

--- a/packages/core/src/core/loroEventApply.ts
+++ b/packages/core/src/core/loroEventApply.ts
@@ -8,7 +8,7 @@ import {
     LoroEventBatch,
     TreeID,
 } from "loro-crdt";
-import { defineCidProperty, isTreeID } from "./utils";
+import { defineCidProperty, isTreeID } from "./utils.js";
 
 // Plain JSON-like value held in Mirror state (no `any`)
 type JSONPrimitive = string | number | boolean | null | undefined;

--- a/packages/core/src/core/mirror.ts
+++ b/packages/core/src/core/mirror.ts
@@ -18,7 +18,7 @@ import {
     TreeID,
 } from "loro-crdt";
 
-import { applyEventBatchToState } from "./loroEventApply";
+import { applyEventBatchToState } from "./loroEventApply.js";
 import {
     ContainerSchemaType,
     getDefaultValue,
@@ -36,7 +36,7 @@ import {
     RootSchemaType,
     SchemaType,
     validateSchema,
-} from "../schema";
+} from "../schema/index.js";
 import {
     deepEqual,
     inferContainerTypeFromValue,
@@ -46,9 +46,9 @@ import {
     tryInferContainerType,
     getRootContainerByType,
     defineCidProperty,
-} from "./utils";
-import { diffContainer, diffTree } from "./diff";
-import { CID_KEY } from "../constants";
+} from "./utils.js";
+import { diffContainer, diffTree } from "./diff.js";
+import { CID_KEY } from "../constants.js";
 
 // Plain JSON-like value used for state snapshots
 type JSONPrimitive = string | number | boolean | null | undefined;
@@ -98,7 +98,7 @@ export interface MirrorOptions<S extends SchemaType> {
     /**
      * Initial state (optional)
      */
-    initialState?: Partial<import("../schema").InferInputType<S>>;
+    initialState?: Partial<import("../schema/index.js").InferInputType<S>>;
 
     /**
      * Whether to validate state updates against the schema
@@ -726,10 +726,7 @@ export class Mirror<S extends SchemaType> {
     /**
      * Update Loro based on state changes
      */
-    private updateLoro(
-        newState: InferType<S>,
-        options?: SetStateOptions,
-    ) {
+    private updateLoro(newState: InferType<S>, options?: SetStateOptions) {
         if (this.syncing) return;
 
         this.syncing = true;

--- a/packages/core/src/core/utils.ts
+++ b/packages/core/src/core/utils.ts
@@ -3,9 +3,9 @@
  */
 
 import { Container, ContainerID, ContainerType, LoroDoc } from "loro-crdt";
-import { SchemaType } from "../schema";
-import { Change, InferContainerOptions } from "./mirror";
-import { CID_KEY } from "../constants";
+import { SchemaType } from "../schema/index.js";
+import { Change, InferContainerOptions } from "./mirror.js";
+import { CID_KEY } from "../constants.js";
 
 export function defineCidProperty(target: unknown, cid: ContainerID) {
     if (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 // Re-export all public APIs
-export * from "./schema";
+export * from "./schema/index.js";
 export {
     Mirror,
     toNormalizedJson,
@@ -14,11 +14,11 @@ export {
     type SubscriberCallback,
     type InferContainerOptions,
     SyncDirection,
-} from "./core";
+} from "./core/index.js";
 
 // Default export
-import * as schema from "./schema";
-import * as core from "./core";
+import * as schema from "./schema/index.js";
+import * as core from "./core/index.js";
 
 type Combined = typeof schema & typeof core;
 const loroMirror: Combined = Object.assign({}, schema, core);

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -21,10 +21,10 @@ import {
     SchemaType,
     StringSchemaType,
     InferType,
-} from "./types";
+} from "./types.js";
 
-export * from "./types";
-export * from "./validators";
+export * from "./types.js";
+export * from "./validators.js";
 
 /**
  * Create a schema definition

--- a/packages/core/src/schema/validators.ts
+++ b/packages/core/src/schema/validators.ts
@@ -12,8 +12,8 @@ import {
     LoroTreeSchema,
     RootSchemaType,
     SchemaType,
-} from "./types";
-import { isObject } from "../core/utils";
+} from "./types.js";
+import { isObject } from "../core/utils.js";
 
 const schemaValidationCache = new WeakMap<object, WeakSet<object>>();
 

--- a/packages/core/tests/cid.test.ts
+++ b/packages/core/tests/cid.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, expectTypeOf } from "vitest";
 import { LoroDoc, LoroMap } from "loro-crdt";
-import { Mirror } from "../src/core/mirror";
-import { schema } from "../src/schema";
-import { InferType } from "../src";
-import { CID_KEY } from "../src/constants";
-import { diffMap } from "../src/core/diff";
+import { Mirror } from "../src/core/mirror.js";
+import { schema } from "../src/schema/index.js";
+import { InferType } from "../src/index.js";
+import { CID_KEY } from "../src/constants.js";
+import { diffMap } from "../src/core/diff.js";
 
 describe("$cid: state injection and write ignoring (always-on for LoroMap)", () => {
     it("types: LoroMap includes $cid by default", () => {

--- a/packages/core/tests/diff-equality.test.ts
+++ b/packages/core/tests/diff-equality.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { LoroDoc } from "loro-crdt";
-import { diffContainer } from "../src/core/diff";
-import { schema } from "../src/schema";
+import { diffContainer } from "../src/core/diff.js";
+import { schema } from "../src/schema/index.js";
 
 describe("diffMap equality for falsy primitives", () => {
     it("does not emit changes when string field stays ''", () => {

--- a/packages/core/tests/inferType.test-d.ts
+++ b/packages/core/tests/inferType.test-d.ts
@@ -1,5 +1,5 @@
 import { test, expectTypeOf, describe } from "vitest";
-import { InferType, schema } from "../src";
+import { InferType, schema } from "../src/index.js";
 
 describe("infer type", () => {
     test("catchall", () => {

--- a/packages/core/tests/issue.test.ts
+++ b/packages/core/tests/issue.test.ts
@@ -1,6 +1,6 @@
 import { it, expect } from "vitest";
 import { LoroDoc, LoroMap } from "loro-crdt";
-import { Mirror, schema } from "../src/";
+import { Mirror, schema } from "../src/index.js";
 
 it("Applying remote event then calling setState immediately may cause an event apply order issue", async () => {
     const docA = new LoroDoc();

--- a/packages/core/tests/list.test.ts
+++ b/packages/core/tests/list.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { longestIncreasingSubsequence } from "../src/core/diff";
-import { Mirror, schema } from "../src";
+import { longestIncreasingSubsequence } from "../src/core/diff.js";
+import { Mirror, schema } from "../src/index.js";
 import { LoroDoc } from "loro-crdt";
 
 describe("longestIncreasingSubsequence", () => {

--- a/packages/core/tests/mirror-list-updates.test.ts
+++ b/packages/core/tests/mirror-list-updates.test.ts
@@ -4,9 +4,9 @@
  * based on whether an idSelector is provided
  */
 
-import { Mirror } from "../src/core/mirror";
+import { Mirror } from "../src/core/mirror.js";
 import { LoroDoc, LoroMap } from "loro-crdt";
-import { schema } from "../src/schema";
+import { schema } from "../src/schema/index.js";
 import { describe, expect, it } from "vitest";
 
 // Utility function to wait for sync to complete (three microtasks for better reliability)

--- a/packages/core/tests/mirror-movable-list.test.ts
+++ b/packages/core/tests/mirror-movable-list.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable unicorn/consistent-function-scoping */
-import { Mirror } from "../src/core/mirror";
+import { Mirror } from "../src/core/mirror.js";
 import { LoroDoc } from "loro-crdt";
-import { schema } from "../src/schema";
+import { schema } from "../src/schema/index.js";
 import { describe, expect, it } from "vitest";
-import { valueIsContainerOfType } from "../src/core/utils";
+import { valueIsContainerOfType } from "../src/core/utils.js";
 
 // Utility function to wait for sync to complete (three microtasks for better reliability)
 const waitForSync = async () => {

--- a/packages/core/tests/mirror-tags.test.ts
+++ b/packages/core/tests/mirror-tags.test.ts
@@ -1,5 +1,5 @@
-import { Mirror, SyncDirection, UpdateMetadata } from "../src/core/mirror";
-import { schema } from "../src/schema";
+import { Mirror, SyncDirection, UpdateMetadata } from "../src/core/mirror.js";
+import { schema } from "../src/schema/index.js";
 import { LoroDoc } from "loro-crdt";
 import { describe, expect, it } from "vitest";
 

--- a/packages/core/tests/mirror-text.test.ts
+++ b/packages/core/tests/mirror-text.test.ts
@@ -1,8 +1,8 @@
-import { Mirror } from "../src/core/mirror";
+import { Mirror } from "../src/core/mirror.js";
 import { LoroDoc, LoroText } from "loro-crdt";
-import { schema } from "../src/schema";
+import { schema } from "../src/schema/index.js";
 import { describe, expect, it } from "vitest";
-import { valueIsContainer, valueIsContainerOfType } from "../src/core/utils";
+import { valueIsContainer, valueIsContainerOfType } from "../src/core/utils.js";
 
 // Utility function to wait for sync to complete (three microtasks for better reliability)
 const waitForSync = async () => {

--- a/packages/core/tests/mirror-tree.test.ts
+++ b/packages/core/tests/mirror-tree.test.ts
@@ -2,9 +2,9 @@
 /* eslint-disable unicorn/consistent-function-scoping */
 import { describe, it, expect } from "vitest";
 import { LoroDoc, LoroText, type LoroEventBatch } from "loro-crdt";
-import { Mirror } from "../src/core/mirror";
-import { applyEventBatchToState } from "../src/core/loroEventApply";
-import { schema } from "../src/schema";
+import { Mirror } from "../src/core/mirror.js";
+import { applyEventBatchToState } from "../src/core/loroEventApply.js";
+import { schema } from "../src/schema/index.js";
 
 // Small helper to wait for microtasks (mirror commits async)
 const tick = async () => {

--- a/packages/core/tests/mirror.human.test.ts
+++ b/packages/core/tests/mirror.human.test.ts
@@ -1,5 +1,5 @@
-import { Mirror } from "../src/core/mirror";
-import { schema } from "../src/schema";
+import { Mirror } from "../src/core/mirror.js";
+import { schema } from "../src/schema/index.js";
 import { isContainer, LoroDoc, LoroMap } from "loro-crdt";
 import { expect, it } from "vitest";
 

--- a/packages/core/tests/mirror.test.ts
+++ b/packages/core/tests/mirror.test.ts
@@ -1,6 +1,6 @@
-import { Mirror, SyncDirection } from "../src/core/mirror";
-import { valueIsContainer, valueIsContainerOfType } from "../src/core/utils";
-import { schema } from "../src/schema";
+import { Mirror, SyncDirection } from "../src/core/mirror.js";
+import { valueIsContainer, valueIsContainerOfType } from "../src/core/utils.js";
+import { schema } from "../src/schema/index.js";
 import { LoroDoc, LoroList, LoroMap } from "loro-crdt";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/tests/null-in-map-consistency.test.ts
+++ b/packages/core/tests/null-in-map-consistency.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { LoroDoc, LoroMap, LoroList } from "loro-crdt";
-import { Mirror, schema, toNormalizedJson } from "../src";
+import { Mirror, schema, toNormalizedJson } from "../src/index.js";
 
 function stripCid(value: unknown): unknown {
     if (Array.isArray(value)) return value.map(stripCid);

--- a/packages/core/tests/readme.quickstart.test.ts
+++ b/packages/core/tests/readme.quickstart.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { LoroDoc } from "loro-crdt";
-import { Mirror, schema, validateSchema } from "../src";
+import { Mirror, schema, validateSchema } from "../src/index.js";
 
 describe("README Quick Start examples", () => {
     it("creates a store, updates immutably and via draft, and injects cid", async () => {

--- a/packages/core/tests/schema-catchall.test.ts
+++ b/packages/core/tests/schema-catchall.test.ts
@@ -2,7 +2,7 @@
  * Test for schema catchall functionality
  */
 import { describe, it, expect } from "vitest";
-import { schema } from "../src/schema";
+import { schema } from "../src/schema/index.js";
 
 describe("Schema Catchall Functionality", () => {
     it("should create a schema with catchall support", () => {

--- a/packages/core/tests/state.test.ts
+++ b/packages/core/tests/state.test.ts
@@ -8,8 +8,8 @@ import {
     RootSchemaType,
     schema,
     StringSchemaType,
-} from "../src/schema";
-import { Mirror, SyncDirection } from "../src/core/mirror";
+} from "../src/schema/index.js";
+import { Mirror, SyncDirection } from "../src/core/mirror.js";
 import { LoroDoc } from "loro-crdt";
 
 // Utility to wait for sync to complete (three microtasks for reliable sync)

--- a/packages/core/tests/utils.test.ts
+++ b/packages/core/tests/utils.test.ts
@@ -4,7 +4,7 @@ import {
     getPathValue,
     setPathValue,
     isObject,
-} from "../src/core/utils";
+} from "../src/core/utils.js";
 
 describe("Utility Functions", () => {
     describe("isObject", () => {

--- a/packages/core/tests/validator.test.ts
+++ b/packages/core/tests/validator.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LoroDoc } from "loro-crdt";
-import { Mirror } from "../src/core/mirror";
-import { schema, validateSchema } from "../src/schema";
-import * as schemaModule from "../src/schema";
+import { Mirror } from "../src/core/mirror.js";
+import { schema, validateSchema } from "../src/schema/index.js";
+import * as schemaModule from "../src/schema/index.js";
 
 describe("schema validator caching", () => {
     let doc: LoroDoc;

--- a/packages/jotai/tests/index.test.tsx
+++ b/packages/jotai/tests/index.test.tsx
@@ -3,7 +3,7 @@ import { useAtom } from "jotai";
 import { LoroDoc } from "loro-crdt";
 import { schema } from "loro-mirror";
 import { afterEach, describe, expect, it } from "vitest";
-import { loroMirrorAtom } from "../src";
+import { loroMirrorAtom } from "../src/index.js";
 
 // Helper to wait for Jotai state propagation
 const waitFor = (ms: number) =>

--- a/packages/jotai/tests/readme.jotai.test.tsx
+++ b/packages/jotai/tests/readme.jotai.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { LoroDoc } from "loro-crdt";
 import { InferInputType, schema } from "loro-mirror";
-import { loroMirrorAtom } from "../src";
+import { loroMirrorAtom } from "../src/index.js";
 import { atom, useAtomValue, useSetAtom } from "jotai";
 
 describe("Jotai README example", () => {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,4 +2,4 @@
  * React integration for Loro Mirror
  */
 
-export * from "./hooks";
+export * from "./hooks.js";

--- a/packages/react/tests/readme.react.context.test.ts
+++ b/packages/react/tests/readme.react.context.test.ts
@@ -5,7 +5,7 @@ import {
     useLoroStore,
     useLoroValue,
     useLoroCallback,
-} from "../src";
+} from "../src/index.js";
 
 describe("React README examples", () => {
     it("createLoroContext returns provider and hooks for given schema", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
         "target": "ES2020",
-        "module": "ESNext",
-        "moduleResolution": "node",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
         "esModuleInterop": true,
         "strict": true,
         "skipLibCheck": true,


### PR DESCRIPTION
Fixes #53 

This change fixes import resolution errors that occur when consuming loro-mirror in strict ESM environments.

## Problem

The package used directory imports like `from "./schema"` which TypeScript compiles as-is. This causes two distinct failures:

1. **Runtime** (Node.js ESM / Vitest): "Directory import is not supported resolving ES modules" - Node.js ESM requires explicit file extensions.

2. **Compile time** (TypeScript with `moduleResolution: "NodeNext"`): "Module 'loro-mirror' has no exported member 'RootSchemaType'" - TypeScript can't resolve `./schema` to `./schema/index.d.ts` in strict mode.

Consumers using lenient resolution modes (`bundler`, legacy `node`) are unaffected.
## Solution

1. Changed tsconfig.json to use `module: "NodeNext"` and `moduleResolution: "NodeNext"`
2. Added explicit `.js` extensions to all relative imports

## Sources

I find the tsconfig settings to be wildly confusing, but these seemed to indicate this was the right choice:

- [How to Create an NPM Package](https://www.totaltypescript.com/how-to-create-an-npm-package) by Matt Pocock (Total TypeScript)
- [Is NodeNext right for libraries?](https://blog.andrewbran.ch/is-nodenext-right-for-libraries-that-dont-target-node-js/
) by Andrew Branch (TypeScript team)

## Consequences

- All relative imports must now include explicit `.js` extensions
- TypeScript will error at compile time if extensions are missing
- Consumers no longer need workarounds like Vitest's `server.deps.inline`
- Works with all TypeScript moduleResolution modes (bundler, node, NodeNext)