### PR TITLE
Add unit test and fix for schema.LoroTree example from README docs (#65)

### DIFF
--- a/packages/core/src/core/mirror.ts
+++ b/packages/core/src/core/mirror.ts
@@ -2515,6 +2515,10 @@ function mergeInitialIntoBaseWithSchema(
             if (!(k in base)) base[k] = "";
             continue;
         }
+        if (t === "loro-tree") {
+            if (!(k in base)) base[k] = [];
+            continue;
+        }
         if (t === "string" || t === "number" || t === "boolean") {
             if (!(k in base)) base[k] = initVal;
             continue;

--- a/packages/core/src/schema/validators.ts
+++ b/packages/core/src/schema/validators.ts
@@ -438,7 +438,11 @@ export function getDefaultValue<S extends SchemaType>(
         case "loro-list":
             return [] as InferType<S>;
         case "loro-tree": {
-            const value = schema.options.required ? [] : undefined;
+            const required =
+                schema.options.required !== undefined
+                    ? schema.options.required
+                    : true;
+            const value = required ? [] : undefined;
             if (value === undefined) return undefined;
             return value as InferType<S>;
         }

--- a/packages/core/tests/mirror-tree.test.ts
+++ b/packages/core/tests/mirror-tree.test.ts
@@ -1117,4 +1117,20 @@ describe("LoroTree integration", () => {
 
         expect(m.getState().root.tree[0].data.desc).toBe("world");
     });
+
+    it("Schema - LoroTree example from README docs works (#65)", async () => {
+        /*
+            The example of using schema.LoroMap() from the README docs
+            failed with `Cannot read properties of undefined (reading 'push')`
+            https://github.com/loro-dev/loro-mirror/issues/65
+        */
+        const node = schema.LoroMap({
+            name: schema.String({ required: true }),
+        });
+        const s = schema({ tree: schema.LoroTree(node) });
+        const mirror = new Mirror({ doc: new LoroDoc(), schema: s });
+        mirror.setState((st) => {
+            st.tree.push({ data: { name: "root" }, children: [] });
+        });
+    });
 });


### PR DESCRIPTION
Fixes #65. Adds a unit test with the `schema.LoroTree` example from the README docs, and resolves making the example code pass. Previously I got `TypeError: Cannot read properties of undefined (reading 'push')` when trying to invoke the example.

Would be great if I could have a review on this (I'm not too deep into the internals of this repo), and feedback is welcome if there's a better resolution (like fixing the docs example). Thank you!