### PR TITLE
infer correct type for schema.String<T>({ required: false })

### DIFF
--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -64,12 +64,12 @@ schema.String = function <T extends string = string, O extends SchemaOptions = {
 } as {
     // Overload 1: No options - default required string
     <T extends string = string>(): StringSchemaType<T> & { options: {} };
-    // Overload 2: With required: false (single generic) - O inferred from literal
-    <T extends string = string>(
-        options: { required: false } & SchemaOptions,
-    ): StringSchemaType<T> & { options: { required: false } };
+    // Overload 2: With required: false (single generic) - infer full options type
+    <T extends string = string, O extends SchemaOptions & { required: false } = { required: false }>(
+        options: O,
+    ): StringSchemaType<T> & { options: O };
     // Overload 3: Explicit O type parameter (backwards compatible)
-    <T extends string = string, O extends SchemaOptions = SchemaOptions>(
+    <T extends string = string, O extends SchemaOptions = {}>(
         options: O,
     ): StringSchemaType<T> & { options: O };
 };

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -51,10 +51,9 @@ export function schema<
 /**
  * Define a string field
  */
-schema.String = function <
-    T extends string = string,
-    O extends SchemaOptions = {},
->(options?: O) {
+schema.String = function <T extends string = string, O extends SchemaOptions = {}>(
+    options?: O,
+): StringSchemaType<T> & { options: O } {
     return {
         type: "string" as const,
         options: (options || {}) as O,
@@ -62,6 +61,17 @@ schema.String = function <
             return null;
         },
     } as StringSchemaType<T> & { options: O };
+} as {
+    // Overload 1: No options - default required string
+    <T extends string = string>(): StringSchemaType<T> & { options: {} };
+    // Overload 2: With required: false (single generic) - O inferred from literal
+    <T extends string = string>(
+        options: { required: false } & SchemaOptions,
+    ): StringSchemaType<T> & { options: { required: false } };
+    // Overload 3: Explicit O type parameter (backwards compatible)
+    <T extends string = string, O extends SchemaOptions = SchemaOptions>(
+        options: O,
+    ): StringSchemaType<T> & { options: O };
 };
 
 /**

--- a/packages/core/tests/inferType.test-d.ts
+++ b/packages/core/tests/inferType.test-d.ts
@@ -82,4 +82,14 @@ describe("infer type", () => {
 
         expectTypeOf<InferredType>().toEqualTypeOf<UserId | undefined>();
     });
+
+    test("infer custom string type with required: false (single generic)", () => {
+        type UserId = string & { _brand: "userId" };
+        // Key test: providing only T, letting O be inferred from the argument
+        const optionalUserIdSchema = schema.String<UserId>({ required: false });
+
+        type InferredType = InferType<typeof optionalUserIdSchema>;
+
+        expectTypeOf<InferredType>().toEqualTypeOf<UserId | undefined>();
+    });
 });

--- a/packages/core/tests/inferType.test-d.ts
+++ b/packages/core/tests/inferType.test-d.ts
@@ -92,4 +92,5 @@ describe("infer type", () => {
 
         expectTypeOf<InferredType>().toEqualTypeOf<UserId | undefined>();
     });
+
 });


### PR DESCRIPTION
When using schema.String<CustomType>({ required: false }) with only one type parameter, TypeScript would default the second type parameter O to {} instead of inferring it from the argument. This caused the inferred type to be CustomType instead of CustomType | undefined.

Fixed by adding function overloads that specifically handle the { required: false } case, allowing the options type to be captured correctly without requiring explicit type parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)