### PR TITLE
fix(core): avoid double mirror startup traversal

### DIFF
--- a/packages/core/src/core/mirror.ts
+++ b/packages/core/src/core/mirror.ts
@@ -78,6 +78,10 @@ interface MirrorStateObject {
     [k: string]: MirrorState;
 }
 
+type RootSnapshotOptions = {
+    registerContainers?: boolean;
+};
+
 /**
  * Values allowed for root-level keys of `initialState`. LoroDoc only stores
  * container types at the root, so primitives (bare `number`/`boolean`) are
@@ -410,22 +414,16 @@ export class Mirror<S extends SchemaType> {
 
         // Initialize in-memory state without writing to LoroDoc:
         // 1) Start from schema defaults (if any)
-        // 2) Overlay current LoroDoc snapshot (normalized)
-        // 3) Fill any missing top-level keys hinted by initialState with a normalized empty shape
+        // 2) Fill any missing top-level keys hinted by initialState with a normalized empty shape
         //    (arrays -> [], strings -> '', objects -> {}), but do NOT override existing values
         //    from the doc/defaults. This keeps doc pristine while providing a predictable state shape.
+        // 3) After container registration, initializeContainers overlays the current LoroDoc snapshot.
         const baseState: Record<string, unknown> = {};
         const defaults = (
             this.schema ? getDefaultValue(this.schema) : undefined
         ) as Record<string, unknown> | undefined;
         if (defaults && typeof defaults === "object") {
             Object.assign(baseState, defaults);
-        }
-
-        // Overlay the current doc snapshot so real data takes precedence over defaults
-        const docSnapshot = this.buildRootStateSnapshot();
-        if (docSnapshot && typeof docSnapshot === "object") {
-            Object.assign(baseState, docSnapshot);
         }
 
         // Merge initialState with awareness of schema:
@@ -579,14 +577,18 @@ export class Mirror<S extends SchemaType> {
                         );
                         // Record canonical root path for this root container id
                         this.rootPathById.set(container.id, [key]);
-                        this.registerContainerHandle(container, fieldSchema);
+                        this.registerContainerHandle(container, fieldSchema, {
+                            scanNested: false,
+                        });
                     }
                 }
             }
         }
 
         // Build initial state snapshot from the current document
-        const currentDocState = this.buildRootStateSnapshot();
+        const currentDocState = this.buildRootStateSnapshot(undefined, {
+            registerContainers: true,
+        });
         const newState = produce<InferType<S>>((draft) => {
             Object.assign(
                 draft as unknown as Record<string, unknown>,
@@ -601,8 +603,10 @@ export class Mirror<S extends SchemaType> {
     private registerContainerHandle(
         container: Container,
         schemaType: ContainerSchemaType | undefined,
+        options: { scanNested?: boolean } = {},
     ) {
         const containerId = container.id;
+        const shouldScanNested = options.scanNested !== false;
 
         // If already registered, optionally upgrade schema
         const existing = this.containerRegistry.get(containerId);
@@ -612,7 +616,9 @@ export class Mirror<S extends SchemaType> {
                 // Schema was missing on initial registration (e.g. from
                 // ensureRootContainersFromInitialState), so nested
                 // containers were never scanned. Do it now.
-                this.registerNestedContainers(container);
+                if (shouldScanNested) {
+                    this.registerNestedContainers(container);
+                }
             }
             return;
         }
@@ -620,7 +626,71 @@ export class Mirror<S extends SchemaType> {
         this.registerContainerWithRegistry(containerId, schemaType);
 
         // Register nested containers
-        this.registerNestedContainers(container);
+        if (shouldScanNested) {
+            this.registerNestedContainers(container);
+        }
+    }
+
+    private registerSnapshotChildContainer(
+        parent: Container,
+        child: Container,
+        childKey?: string | number,
+    ) {
+        const parentSchema = this.getContainerSchema(parent.id);
+        const parentLocalInfer = this.inferOptionsByContainerId.get(parent.id);
+        let nestedSchema: ContainerSchemaType | undefined;
+
+        if (parent.kind() === "Map") {
+            if (
+                parentSchema &&
+                isLoroMapSchema(parentSchema) &&
+                typeof childKey === "string"
+            ) {
+                const candidate = getMapFieldSchema(parentSchema, childKey);
+                if (candidate?.type === "any") {
+                    this.inferOptionsByContainerId.set(
+                        child.id,
+                        this.getInferOptionsForChild(parent.id, candidate),
+                    );
+                }
+                if (candidate && isContainerSchema(candidate)) {
+                    nestedSchema = candidate;
+                }
+            }
+        } else if (
+            parent.kind() === "List" ||
+            parent.kind() === "MovableList"
+        ) {
+            if (
+                parentSchema &&
+                (isLoroListSchema(parentSchema) ||
+                    isLoroMovableListSchema(parentSchema))
+            ) {
+                const itemSchema = parentSchema.itemSchema;
+                if (itemSchema?.type === "any") {
+                    this.inferOptionsByContainerId.set(
+                        child.id,
+                        this.getInferOptionsForChild(parent.id, itemSchema),
+                    );
+                }
+                if (isContainerSchema(itemSchema)) {
+                    nestedSchema = itemSchema;
+                }
+            }
+        }
+
+        if (
+            !parentSchema &&
+            !nestedSchema &&
+            parentLocalInfer &&
+            !this.inferOptionsByContainerId.has(child.id)
+        ) {
+            this.inferOptionsByContainerId.set(child.id, parentLocalInfer);
+        }
+
+        this.registerContainerHandle(child, nestedSchema, {
+            scanNested: false,
+        });
     }
 
     /**
@@ -2664,7 +2734,10 @@ export class Mirror<S extends SchemaType> {
         }
     }
 
-    private containerToMirrorState(c: Container): MirrorState {
+    private containerToMirrorState(
+        c: Container,
+        options: RootSnapshotOptions = {},
+    ): MirrorState {
         const kind = c.kind();
         const schema = this.getContainerSchema(c.id);
         if (kind === "Map") {
@@ -2674,7 +2747,10 @@ export class Mirror<S extends SchemaType> {
             for (const k of m.keys()) {
                 const v = m.get(k);
                 if (isContainer(v)) {
-                    obj[k] = this.containerToMirrorState(v);
+                    if (options.registerContainers) {
+                        this.registerSnapshotChildContainer(c, v, k);
+                    }
+                    obj[k] = this.containerToMirrorState(v, options);
                 } else {
                     // Decode primitive values using field schema
                     const fieldSchema = getChildSchema(schema, k);
@@ -2691,7 +2767,10 @@ export class Mirror<S extends SchemaType> {
             for (let i = 0; i < len; i++) {
                 const v = l.get(i);
                 if (isContainer(v)) {
-                    arr.push(this.containerToMirrorState(v));
+                    if (options.registerContainers) {
+                        this.registerSnapshotChildContainer(c, v, i);
+                    }
+                    arr.push(this.containerToMirrorState(v, options));
                 } else {
                     // Decode primitive items using item schema
                     arr.push(applyDecode(itemSchema, v) as MirrorState);
@@ -2703,6 +2782,9 @@ export class Mirror<S extends SchemaType> {
             return (c as LoroText).toJSON();
         } else if (kind === "Tree") {
             const t = c as LoroTree;
+            if (options.registerContainers) {
+                this.registerNestedContainers(c);
+            }
             // Normalize via toJSON first
             const normalized = normalizeTreeJsonForMirror(t.toJSON());
             // Optionally inject $cid per node.data using an id->cid map from live nodes
@@ -2778,6 +2860,7 @@ export class Mirror<S extends SchemaType> {
      */
     private buildRootStateSnapshot(
         prevState?: Record<string, unknown>,
+        options: RootSnapshotOptions = {},
     ): Record<string, unknown> {
         if (!this.schema || this.schema.type !== "schema") {
             // Fallback to previous normalization if no schema
@@ -2806,22 +2889,25 @@ export class Mirror<S extends SchemaType> {
             );
             // Always include maps to expose $cid for stable identity
             if (containerType === "Map") {
-                root[key] = this.containerToMirrorState(container);
+                root[key] = this.containerToMirrorState(container, options);
             } else if (
                 containerType === "List" ||
                 containerType === "MovableList"
             ) {
                 // Always include lists, even if empty, to match Mirror's state shape
-                root[key] = this.containerToMirrorState(container);
+                root[key] = this.containerToMirrorState(container, options);
             } else if (containerType === "Text") {
                 // Always include text, even if empty, to match Mirror's state shape
-                root[key] = this.containerToMirrorState(container);
+                root[key] = this.containerToMirrorState(container, options);
             } else if (containerType === "Tree") {
-                const arr = this.containerToMirrorState(container) as unknown[];
+                const arr = this.containerToMirrorState(
+                    container,
+                    options,
+                ) as unknown[];
                 if (!Array.isArray(arr) || arr.length === 0) continue;
                 root[key] = arr;
             } else {
-                root[key] = this.containerToMirrorState(container);
+                root[key] = this.containerToMirrorState(container, options);
             }
         }
         return root;

--- a/packages/core/src/core/mirror.ts
+++ b/packages/core/src/core/mirror.ts
@@ -82,6 +82,15 @@ type RootSnapshotOptions = {
     registerContainers?: boolean;
 };
 
+type RegisterContainerOptions = {
+    scanNested?: boolean;
+};
+
+type ChildRegistrationContext = {
+    parentSchema: ContainerSchemaType | undefined;
+    parentLocalInfer: InferContainerOptions | undefined;
+};
+
 /**
  * Values allowed for root-level keys of `initialState`. LoroDoc only stores
  * container types at the root, so primitives (bare `number`/`boolean`) are
@@ -603,7 +612,7 @@ export class Mirror<S extends SchemaType> {
     private registerContainerHandle(
         container: Container,
         schemaType: ContainerSchemaType | undefined,
-        options: { scanNested?: boolean } = {},
+        options: RegisterContainerOptions = {},
     ) {
         const containerId = container.id;
         const shouldScanNested = options.scanNested !== false;
@@ -631,13 +640,14 @@ export class Mirror<S extends SchemaType> {
         }
     }
 
-    private registerSnapshotChildContainer(
+    private registerChildContainer(
         parent: Container,
         child: Container,
-        childKey?: string | number,
+        childKey: string | number,
+        context: ChildRegistrationContext,
+        options: RegisterContainerOptions = {},
     ) {
-        const parentSchema = this.getContainerSchema(parent.id);
-        const parentLocalInfer = this.inferOptionsByContainerId.get(parent.id);
+        const { parentSchema, parentLocalInfer } = context;
         let nestedSchema: ContainerSchemaType | undefined;
 
         if (parent.kind() === "Map") {
@@ -688,9 +698,16 @@ export class Mirror<S extends SchemaType> {
             this.inferOptionsByContainerId.set(child.id, parentLocalInfer);
         }
 
-        this.registerContainerHandle(child, nestedSchema, {
-            scanNested: false,
-        });
+        this.registerContainerHandle(child, nestedSchema, options);
+    }
+
+    private getChildRegistrationContext(
+        parent: Container,
+    ): ChildRegistrationContext {
+        return {
+            parentSchema: this.getContainerSchema(parent.id),
+            parentLocalInfer: this.inferOptionsByContainerId.get(parent.id),
+        };
     }
 
     /**
@@ -699,48 +716,19 @@ export class Mirror<S extends SchemaType> {
     private registerNestedContainers(container: Container) {
         if (!container.isAttached) return;
 
-        const parentSchema = this.getContainerSchema(container.id);
-        const parentLocalInfer = this.inferOptionsByContainerId.get(
-            container.id,
-        );
-
         try {
             if (container.kind() === "Map") {
                 const map = container as LoroMap;
+                const context = this.getChildRegistrationContext(container);
                 for (const key of map.keys()) {
                     const value = map.get(key);
                     if (isContainer(value)) {
-                        let nestedSchema: ContainerSchemaType | undefined;
-                        if (parentSchema && isLoroMapSchema(parentSchema)) {
-                            const candidate = getMapFieldSchema(
-                                parentSchema,
-                                key,
-                            );
-                            if (candidate?.type === "any") {
-                                this.inferOptionsByContainerId.set(
-                                    value.id,
-                                    this.getInferOptionsForChild(
-                                        container.id,
-                                        candidate,
-                                    ),
-                                );
-                            }
-                            if (candidate && isContainerSchema(candidate)) {
-                                nestedSchema = candidate;
-                            }
-                        }
-                        if (
-                            !parentSchema &&
-                            !nestedSchema &&
-                            parentLocalInfer &&
-                            !this.inferOptionsByContainerId.has(value.id)
-                        ) {
-                            this.inferOptionsByContainerId.set(
-                                value.id,
-                                parentLocalInfer,
-                            );
-                        }
-                        this.registerContainerHandle(value, nestedSchema);
+                        this.registerChildContainer(
+                            container,
+                            value,
+                            key,
+                            context,
+                        );
                     }
                 }
             } else if (
@@ -748,46 +736,23 @@ export class Mirror<S extends SchemaType> {
                 container.kind() === "MovableList"
             ) {
                 const list = container as LoroList | LoroMovableList;
+                const context = this.getChildRegistrationContext(container);
                 const len = list.length;
                 for (let i = 0; i < len; i++) {
                     const value = list.get(i);
                     if (isContainer(value)) {
-                        let nestedSchema: ContainerSchemaType | undefined;
-                        if (
-                            parentSchema &&
-                            (isLoroListSchema(parentSchema) ||
-                                isLoroMovableListSchema(parentSchema))
-                        ) {
-                            const itemSchema = parentSchema.itemSchema;
-                            if (itemSchema?.type === "any") {
-                                this.inferOptionsByContainerId.set(
-                                    value.id,
-                                    this.getInferOptionsForChild(
-                                        container.id,
-                                        itemSchema,
-                                    ),
-                                );
-                            }
-                            if (isContainerSchema(itemSchema)) {
-                                nestedSchema = itemSchema;
-                            }
-                        }
-                        if (
-                            !parentSchema &&
-                            !nestedSchema &&
-                            parentLocalInfer &&
-                            !this.inferOptionsByContainerId.has(value.id)
-                        ) {
-                            this.inferOptionsByContainerId.set(
-                                value.id,
-                                parentLocalInfer,
-                            );
-                        }
-                        this.registerContainerHandle(value, nestedSchema);
+                        this.registerChildContainer(
+                            container,
+                            value,
+                            i,
+                            context,
+                        );
                     }
                 }
             } else if (container.kind() === "Tree") {
                 const tree = container as LoroTree;
+                const { parentSchema, parentLocalInfer } =
+                    this.getChildRegistrationContext(container);
                 let nodeSchema: ContainerSchemaType | undefined;
                 if (parentSchema && isLoroTreeSchema(parentSchema)) {
                     nodeSchema = parentSchema.nodeSchema as ContainerSchemaType;
@@ -2743,12 +2708,23 @@ export class Mirror<S extends SchemaType> {
         if (kind === "Map") {
             const m = c as LoroMap;
             const obj: MirrorStateObject = {};
+            const childRegistrationContext = options.registerContainers
+                ? this.getChildRegistrationContext(c)
+                : undefined;
             defineCidProperty(obj, c.id);
             for (const k of m.keys()) {
                 const v = m.get(k);
                 if (isContainer(v)) {
-                    if (options.registerContainers) {
-                        this.registerSnapshotChildContainer(c, v, k);
+                    if (childRegistrationContext) {
+                        this.registerChildContainer(
+                            c,
+                            v,
+                            k,
+                            childRegistrationContext,
+                            {
+                                scanNested: false,
+                            },
+                        );
                     }
                     obj[k] = this.containerToMirrorState(v, options);
                 } else {
@@ -2762,13 +2738,24 @@ export class Mirror<S extends SchemaType> {
             const arr: MirrorState[] = [];
             const l = c as unknown as LoroList | LoroMovableList;
             const len = l.length;
+            const childRegistrationContext = options.registerContainers
+                ? this.getChildRegistrationContext(c)
+                : undefined;
             // Get item schema for decoding list items
             const itemSchema = getChildSchema(schema);
             for (let i = 0; i < len; i++) {
                 const v = l.get(i);
                 if (isContainer(v)) {
-                    if (options.registerContainers) {
-                        this.registerSnapshotChildContainer(c, v, i);
+                    if (childRegistrationContext) {
+                        this.registerChildContainer(
+                            c,
+                            v,
+                            i,
+                            childRegistrationContext,
+                            {
+                                scanNested: false,
+                            },
+                        );
                     }
                     arr.push(this.containerToMirrorState(v, options));
                 } else {

--- a/packages/core/tests/mirror.test.ts
+++ b/packages/core/tests/mirror.test.ts
@@ -1006,6 +1006,66 @@ describe("Mirror - State Consistency", () => {
         });
     });
 
+    it("builds the root doc snapshot once during construction", () => {
+        const todosSchema = schema({
+            todos: schema.LoroList(
+                schema.LoroMap({
+                    id: schema.String(),
+                    text: schema.String(),
+                }),
+            ),
+        });
+
+        const todos = doc.getList("todos");
+        const todo = todos.insertContainer(0, new LoroMap());
+        todo.set("id", "1");
+        todo.set("text", "already in doc");
+        doc.commit();
+
+        type SnapshotCapableMirror = {
+            buildRootStateSnapshot: (
+                prevState?: Record<string, unknown>,
+            ) => Record<string, unknown>;
+            registerNestedContainers: (container: unknown) => void;
+        };
+        const proto = Mirror.prototype as unknown as SnapshotCapableMirror;
+        const originalBuildRootStateSnapshot = proto.buildRootStateSnapshot;
+        const originalRegisterNestedContainers = proto.registerNestedContainers;
+        let snapshotCalls = 0;
+        let nestedScanCalls = 0;
+
+        proto.buildRootStateSnapshot = function (
+            this: SnapshotCapableMirror,
+            prevState?: Record<string, unknown>,
+        ) {
+            snapshotCalls += 1;
+            return originalBuildRootStateSnapshot.call(this, prevState);
+        };
+        proto.registerNestedContainers = function (
+            this: SnapshotCapableMirror,
+            container: unknown,
+        ) {
+            nestedScanCalls += 1;
+            return originalRegisterNestedContainers.call(this, container);
+        };
+
+        try {
+            const mirror = new Mirror({
+                doc,
+                schema: todosSchema,
+                initialState: { todos: [] },
+            });
+            expect(mirror.getState().todos).toHaveLength(1);
+            mirror.dispose();
+        } finally {
+            proto.buildRootStateSnapshot = originalBuildRootStateSnapshot;
+            proto.registerNestedContainers = originalRegisterNestedContainers;
+        }
+
+        expect(snapshotCalls).toBe(1);
+        expect(nestedScanCalls).toBe(0);
+    });
+
     it("should not write into LoroDoc with initState", async () => {
         const someState = {
             list: [{}],

--- a/packages/core/tests/mirror.test.ts
+++ b/packages/core/tests/mirror.test.ts
@@ -1025,6 +1025,7 @@ describe("Mirror - State Consistency", () => {
         type SnapshotCapableMirror = {
             buildRootStateSnapshot: (
                 prevState?: Record<string, unknown>,
+                options?: { registerContainers?: boolean },
             ) => Record<string, unknown>;
             registerNestedContainers: (container: unknown) => void;
         };
@@ -1032,14 +1033,23 @@ describe("Mirror - State Consistency", () => {
         const originalBuildRootStateSnapshot = proto.buildRootStateSnapshot;
         const originalRegisterNestedContainers = proto.registerNestedContainers;
         let snapshotCalls = 0;
+        let snapshotRegistrationCalls = 0;
         let nestedScanCalls = 0;
 
         proto.buildRootStateSnapshot = function (
             this: SnapshotCapableMirror,
             prevState?: Record<string, unknown>,
+            options?: { registerContainers?: boolean },
         ) {
             snapshotCalls += 1;
-            return originalBuildRootStateSnapshot.call(this, prevState);
+            if (options?.registerContainers) {
+                snapshotRegistrationCalls += 1;
+            }
+            return originalBuildRootStateSnapshot.call(
+                this,
+                prevState,
+                options,
+            );
         };
         proto.registerNestedContainers = function (
             this: SnapshotCapableMirror,
@@ -1056,6 +1066,7 @@ describe("Mirror - State Consistency", () => {
                 initialState: { todos: [] },
             });
             expect(mirror.getState().todos).toHaveLength(1);
+            expect(mirror.getContainerIds()).toContain(todo.id);
             mirror.dispose();
         } finally {
             proto.buildRootStateSnapshot = originalBuildRootStateSnapshot;
@@ -1063,6 +1074,7 @@ describe("Mirror - State Consistency", () => {
         }
 
         expect(snapshotCalls).toBe(1);
+        expect(snapshotRegistrationCalls).toBe(1);
         expect(nestedScanCalls).toBe(0);
     });
 

--- a/packages/core/tests/mirror.test.ts
+++ b/packages/core/tests/mirror.test.ts
@@ -1006,7 +1006,7 @@ describe("Mirror - State Consistency", () => {
         });
     });
 
-    it("builds the root doc snapshot once during construction", () => {
+    it("reads each root list item once during construction", () => {
         const todosSchema = schema({
             todos: schema.LoroList(
                 schema.LoroMap({
@@ -1022,60 +1022,22 @@ describe("Mirror - State Consistency", () => {
         todo.set("text", "already in doc");
         doc.commit();
 
-        type SnapshotCapableMirror = {
-            buildRootStateSnapshot: (
-                prevState?: Record<string, unknown>,
-                options?: { registerContainers?: boolean },
-            ) => Record<string, unknown>;
-            registerNestedContainers: (container: unknown) => void;
-        };
-        const proto = Mirror.prototype as unknown as SnapshotCapableMirror;
-        const originalBuildRootStateSnapshot = proto.buildRootStateSnapshot;
-        const originalRegisterNestedContainers = proto.registerNestedContainers;
-        let snapshotCalls = 0;
-        let snapshotRegistrationCalls = 0;
-        let nestedScanCalls = 0;
-
-        proto.buildRootStateSnapshot = function (
-            this: SnapshotCapableMirror,
-            prevState?: Record<string, unknown>,
-            options?: { registerContainers?: boolean },
-        ) {
-            snapshotCalls += 1;
-            if (options?.registerContainers) {
-                snapshotRegistrationCalls += 1;
-            }
-            return originalBuildRootStateSnapshot.call(
-                this,
-                prevState,
-                options,
-            );
-        };
-        proto.registerNestedContainers = function (
-            this: SnapshotCapableMirror,
-            container: unknown,
-        ) {
-            nestedScanCalls += 1;
-            return originalRegisterNestedContainers.call(this, container);
-        };
+        const getSpy = vi.spyOn(LoroList.prototype, "get");
+        let mirror: Mirror<typeof todosSchema> | undefined;
 
         try {
-            const mirror = new Mirror({
+            mirror = new Mirror({
                 doc,
                 schema: todosSchema,
                 initialState: { todos: [] },
             });
             expect(mirror.getState().todos).toHaveLength(1);
             expect(mirror.getContainerIds()).toContain(todo.id);
-            mirror.dispose();
+            expect(getSpy).toHaveBeenCalledTimes(1);
         } finally {
-            proto.buildRootStateSnapshot = originalBuildRootStateSnapshot;
-            proto.registerNestedContainers = originalRegisterNestedContainers;
+            mirror?.dispose();
+            getSpy.mockRestore();
         }
-
-        expect(snapshotCalls).toBe(1);
-        expect(snapshotRegistrationCalls).toBe(1);
-        expect(nestedScanCalls).toBe(0);
     });
 
     it("should not write into LoroDoc with initState", async () => {


### PR DESCRIPTION
## Summary
- avoid building the root mirror snapshot twice during construction
- register nested map/list containers while walking the startup snapshot instead of doing a separate nested scan first
- keep tree startup registration on the existing nested scan path

## Validation
- pnpm --filter loro-mirror test
- pnpm check
- git diff --check

## Trace note
The Lody trace shows the long startup task split between initializeContainers and buildRootStateSnapshot. This change removes that duplicate map/list traversal. Local Node + loro-crdt/web benchmarks on the provided updates.json still stay in the tens of milliseconds, so this fixes the clear duplicate work but does not by itself explain the full multi-second Chrome trace.