### PR TITLE
fix(core): preserve cid-prefixed user strings

### DIFF
--- a/packages/core/src/core/mirror.ts
+++ b/packages/core/src/core/mirror.ts
@@ -2962,14 +2962,12 @@ export class Mirror<S extends SchemaType> {
 
                 const container = this.doc.getContainerById(containerId);
                 if (!container) {
-                    // Match toJsonWithReplacer's error for an unresolved
-                    // container id so this optimization does not hide a
-                    // corrupt or inconsistent document state.
+                    // Match toNormalizedJson's error for an unresolved container
+                    // id so this optimization does not hide a corrupt or
+                    // inconsistent document state.
                     throw new Error(`ContainerID not found: ${containerId}`);
                 }
-                root[key] = restoreCidDescriptors(
-                    normalizeContainerForJson(container),
-                );
+                root[key] = normalizeContainerForJson(container);
             }
         }
         return root;
@@ -3065,29 +3063,19 @@ export class Mirror<S extends SchemaType> {
  * @param doc
  * @returns
  */
-// Sentinel prefix for $cid values during the `toJsonWithReplacer` pass.
-// `toJsonWithReplacer` re-resolves any *mergeable* container-id string it finds
-// in the replacer's return value back into a container (re-applying the
-// replacer), which corrupts nested `$cid` markers. Prefixing the id makes it an
-// invalid container id so it is left untouched; `restoreCidDescriptors` strips
-// the prefix afterwards.
-const CID_PLACEHOLDER_PREFIX = "\x00mirror:cid\x00";
-
-export function toNormalizedJson(doc: LoroDoc) {
-    // Resolve containers ourselves rather than relying on `toJsonWithReplacer`'s
-    // own recursion: `getShallowValue` leaks mergeable child containers as raw
-    // binary markers, and a container handle placed back into the replacer's
-    // return value is serialized as a raw wasm pointer instead of being recursed
-    // into. Explicit recursion via `get`/`toJSON` resolves both regular and
-    // mergeable children uniformly and injects `$cid` on every Map.
-    const withEnumerableCid = doc.toJsonWithReplacer((_k, v) => {
-        if (isContainer(v)) {
-            return normalizeContainerForJson(v) as unknown as typeof v;
+export function toNormalizedJson(doc: LoroDoc): unknown {
+    // Document shallow values contain only root ContainerIDs. Resolve those IDs,
+    // then normalize through container APIs without sending returned JS values
+    // back to wasm, so `cid:`-prefixed strings stay strings.
+    const root: Record<string, unknown> = {};
+    for (const [key, id] of Object.entries(doc.getShallowValue())) {
+        const container = doc.getContainerById(id);
+        if (!container) {
+            throw new Error(`ContainerID not found: ${id}`);
         }
-        return v;
-    });
-
-    return restoreCidDescriptors(withEnumerableCid);
+        root[key] = normalizeContainerForJson(container);
+    }
+    return root;
 }
 
 function normalizeContainerForJson(c: Container): unknown {
@@ -3102,12 +3090,13 @@ function normalizeContainerForJson(c: Container): unknown {
         const m = c as LoroMap;
         const obj: Record<string, unknown> = {};
         for (const key of m.keys()) {
+            if (key === CID_KEY) continue;
             const child = m.get(key);
             obj[key] = isContainer(child)
                 ? normalizeContainerForJson(child)
                 : child;
         }
-        obj[CID_KEY] = CID_PLACEHOLDER_PREFIX + m.id;
+        defineCidProperty(obj, m.id);
         return obj;
     }
     if (kind === "List" || kind === "MovableList") {
@@ -3123,40 +3112,6 @@ function normalizeContainerForJson(c: Container): unknown {
     }
     // Fallback for any other container kind (e.g. Counter): use its JSON form.
     return (c as unknown as { toJSON(): unknown }).toJSON();
-}
-
-// After toJsonWithReplacer returns plain JSON objects with enumerable $cid,
-// walk the structure and restore the non-enumerable descriptor so mirrored state matches schema mode.
-function restoreCidDescriptors(value: unknown): unknown {
-    if (Array.isArray(value)) {
-        for (let i = 0; i < value.length; i++) {
-            value[i] = restoreCidDescriptors(value[i]);
-        }
-        return value;
-    }
-
-    if (isObject(value)) {
-        const obj = value;
-        for (const key of Object.keys(obj)) {
-            obj[key] = restoreCidDescriptors(obj[key]);
-        }
-        if (Object.prototype.hasOwnProperty.call(obj, CID_KEY)) {
-            const descriptor = Object.getOwnPropertyDescriptor(obj, CID_KEY);
-            if (!descriptor || descriptor.enumerable) {
-                const rawCid = obj[CID_KEY];
-                const cidValue =
-                    typeof rawCid === "string" &&
-                    rawCid.startsWith(CID_PLACEHOLDER_PREFIX)
-                        ? rawCid.slice(CID_PLACEHOLDER_PREFIX.length)
-                        : rawCid;
-                delete obj[CID_KEY];
-                Object.defineProperty(obj, CID_KEY, { value: cidValue });
-            }
-        }
-        return obj;
-    }
-
-    return value;
 }
 
 // Normalize a shallow object shape from provided initialState by converting

--- a/packages/core/tests/normalized-json-cid-strings.test.ts
+++ b/packages/core/tests/normalized-json-cid-strings.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import { LoroDoc, LoroMap } from "loro-crdt";
+import { Mirror, schema, toNormalizedJson } from "../src/index.js";
+
+const INVALID_CID_STRING = "cid:not-a-container\nsecond line\nthird line";
+const MISSING_CONTAINER_ID = "cid:root-missing:Map";
+
+interface CidStringSnapshot {
+    invalidText: string;
+    validText: string;
+    realText: string;
+    strings: {
+        invalid: string;
+        valid: string;
+        real: string;
+        nested: { label: string; $cid: string };
+        $cid: string;
+    };
+    list: Array<string | { label: string; $cid: string }>;
+    movable: Array<string | { label: string; $cid: string }>;
+    target: { payload: string; $cid: string };
+}
+
+function asCidStringSnapshot(value: unknown): CidStringSnapshot {
+    return value as CidStringSnapshot;
+}
+
+function createDocWithCidStrings() {
+    const doc = new LoroDoc();
+    const strings = doc.getMap("strings");
+    const nested = strings.setContainer("nested", new LoroMap());
+    nested.set("label", "nested map");
+
+    const list = doc.getList("list");
+    const listMap = list.pushContainer(new LoroMap());
+    listMap.set("label", "list map");
+
+    const movable = doc.getMovableList("movable");
+    const movableMap = movable.pushContainer(new LoroMap());
+    movableMap.set("label", "movable map");
+
+    const target = doc.getMap("target");
+    target.set("payload", "must remain behind the real container id");
+    const realContainerId = target.id;
+
+    doc.getText("invalidText").insert(0, INVALID_CID_STRING);
+    doc.getText("validText").insert(0, MISSING_CONTAINER_ID);
+    doc.getText("realText").insert(0, realContainerId);
+
+    strings.set("invalid", INVALID_CID_STRING);
+    strings.set("valid", MISSING_CONTAINER_ID);
+    strings.set("real", realContainerId);
+
+    list.insert(0, INVALID_CID_STRING);
+    list.insert(1, MISSING_CONTAINER_ID);
+    list.insert(2, realContainerId);
+
+    movable.insert(0, INVALID_CID_STRING);
+    movable.insert(1, MISSING_CONTAINER_ID);
+    movable.insert(2, realContainerId);
+    doc.commit();
+
+    return {
+        doc,
+        realContainerId,
+        mapIds: [strings.id, nested.id, listMap.id, movableMap.id, target.id],
+    };
+}
+
+function expectCidStrings(
+    snapshot: CidStringSnapshot,
+    realContainerId: string,
+) {
+    expect(snapshot.invalidText).toBe(INVALID_CID_STRING);
+    expect(snapshot.validText).toBe(MISSING_CONTAINER_ID);
+    expect(snapshot.realText).toBe(realContainerId);
+    expect(snapshot.strings.invalid).toBe(INVALID_CID_STRING);
+    expect(snapshot.strings.valid).toBe(MISSING_CONTAINER_ID);
+    expect(snapshot.strings.real).toBe(realContainerId);
+    expect(snapshot.list.slice(0, 3)).toEqual([
+        INVALID_CID_STRING,
+        MISSING_CONTAINER_ID,
+        realContainerId,
+    ]);
+    expect(snapshot.movable.slice(0, 3)).toEqual([
+        INVALID_CID_STRING,
+        MISSING_CONTAINER_ID,
+        realContainerId,
+    ]);
+}
+
+describe("cid:-prefixed user strings", () => {
+    it("normalizes Text, Map, List, and MovableList strings byte-for-byte", () => {
+        const { doc, realContainerId } = createDocWithCidStrings();
+        const replacerSpy = vi.spyOn(doc, "toJsonWithReplacer");
+
+        const snapshot = asCidStringSnapshot(toNormalizedJson(doc));
+
+        expectCidStrings(snapshot, realContainerId);
+        expect(replacerSpy).not.toHaveBeenCalled();
+    });
+
+    it("opens a schema-less Mirror and preserves the strings incrementally", async () => {
+        const { doc, realContainerId } = createDocWithCidStrings();
+
+        const mirror = new Mirror({ doc });
+        expectCidStrings(
+            asCidStringSnapshot(mirror.getState()),
+            realContainerId,
+        );
+
+        const incremental = "cid:incremental\nstill user text";
+        doc.getMap("strings").set("invalid", incremental);
+        doc.getList("list").insert(0, realContainerId);
+        doc.commit();
+        await Promise.resolve();
+
+        const state = asCidStringSnapshot(mirror.getState());
+        expect(state.strings.invalid).toBe(incremental);
+        expect(state.list[0]).toBe(realContainerId);
+    });
+
+    it("preserves strings in unknown roots when a schema ignores them", () => {
+        const { doc, realContainerId } = createDocWithCidStrings();
+        const mirror = new Mirror({
+            doc,
+            schema: schema({
+                target: schema.LoroMap({ payload: schema.String() }),
+            }),
+            ignoreUnknownProperties: true,
+        });
+
+        expectCidStrings(
+            asCidStringSnapshot(mirror.getState()),
+            realContainerId,
+        );
+    });
+
+    it("does not replace a user string equal to a real container id", () => {
+        const { doc, realContainerId } = createDocWithCidStrings();
+
+        const snapshot = asCidStringSnapshot(toNormalizedJson(doc));
+
+        expect(snapshot.realText).toBe(realContainerId);
+        expect(snapshot.strings.real).toBe(realContainerId);
+        expect(snapshot.list[2]).toBe(realContainerId);
+        expect(snapshot.movable[2]).toBe(realContainerId);
+        expect(snapshot.strings.real).not.toEqual(snapshot.target);
+    });
+
+    it("keeps $cid non-enumerable on every normalized Map", () => {
+        const { doc, mapIds } = createDocWithCidStrings();
+        const snapshot = asCidStringSnapshot(toNormalizedJson(doc));
+        const maps = [
+            snapshot.strings,
+            snapshot.strings.nested,
+            snapshot.list[3],
+            snapshot.movable[3],
+            snapshot.target,
+        ];
+
+        maps.forEach((map, index) => {
+            expect(map).toBeTypeOf("object");
+            expect(Object.getOwnPropertyDescriptor(map, "$cid")).toEqual({
+                value: mapIds[index],
+                writable: false,
+                enumerable: false,
+                configurable: false,
+            });
+        });
+    });
+
+    it("keeps the missing root container error", () => {
+        const doc = new LoroDoc();
+        const root = doc.getMap("root");
+        vi.spyOn(doc, "getContainerById").mockReturnValue(undefined);
+
+        expect(() => toNormalizedJson(doc)).toThrow(
+            `ContainerID not found: ${root.id}`,
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- enumerate document root ContainerIDs with getShallowValue and normalize each container directly
- stop passing normalized user values through toJsonWithReplacer
- define non-enumerable $cid markers during Map normalization and remove placeholder restoration
- preserve Tree, Text, Counter, mergeable-container, incremental event, and ignoreUnknownProperties behavior

## Regression coverage
- invalid multiline and valid cid:-prefixed strings in Text, Map, List, and MovableList values
- schema-less Mirror initialization and incremental updates
- schema-based unknown-root snapshots with ignoreUnknownProperties
- strings equal to a real container ID remain strings
- every normalized Map keeps a non-enumerable $cid descriptor
- missing root containers keep the existing error

## Verification
- pnpm build
- pnpm test (44 files, 522 tests)
- pnpm typecheck
- pnpm lint (0 errors; 12 pre-existing warnings)
- isolated loro-crdt 1.14.1: full 44-file, 522-test suite and typecheck passed