### PR TITLE
perf(core): copy paths for single text events

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,22 +1,5 @@
 # Loro Mirror
 
-## Streaming text implementation note
-
-Single-event updates to an existing string leaf copy only that leaf's ancestor
-path instead of using the general Immer draft and descriptor repair pass. Copies
-retain `$cid` descriptors and untouched branch identities; old snapshots remain
-unchanged. Missing baselines, accessor/non-plain paths, tree paths and structural
-or multi-event batches retain the general path. There is no storage or public API
-change. Wide ancestor arrays still require copying; this is not windowed reading.
-
-Run `pnpm build` then `node packages/core/scripts/single-text-event-bench.mjs`
-from the repository root. The synthetic benchmark compares single-text events
-with equivalent batches containing an extra empty text event to force the general
-path (so the control includes that extra event's overhead). It checks equal output,
-warms both paths and alternates order. It measures event application only, not
-end-to-end application performance. The existing event test suite checks real
-Loro edits/imports and includes a non-timing guard against reintroducing drafting.
-
 ## Quick Start
 
 Define a schema and instantiate a `Mirror` with a `LoroDoc`.
@@ -352,6 +335,26 @@ For more React patterns (selectors, actions, provider), see `packages/react/READ
 - Use an `idSelector` whenever list items have stable IDs to get efficient moves instead of delete+insert.
 - `setState` accepts an updater that either mutates a draft or returns a new object — use whichever style you prefer.
 - Subscriptions receive `{ source: LORO | MIRROR | EPHEMERAL, tags?: string[] }`.
+
+### Streaming text implementation note
+
+Single-event updates to an existing string leaf copy only its ancestor path,
+preserving `$cid`, old snapshots and unchanged branch identities. Missing baselines,
+accessor/non-plain paths, tree paths and structural/multi-event batches retain the
+general Immer path. Ordinary dense arrays copy validated data values directly;
+holes, extra keys, accessors or unusual descriptors retain descriptor copying.
+No getters, iterators or species constructors run during this copy. It remains
+O(ancestor width), not windowed reading; storage and public APIs do not change.
+
+Run `pnpm --filter loro-mirror bench:single-text-event`. The synthetic benchmark
+warms each path and alternates five samples of 30 events, checking output equality.
+The general-path control adds an empty text event (its overhead is included).
+Set `TEXT_EVENT_BASELINE` to a module URL exporting `applyEventBatchToState` to
+compare a previous build on exactly the same single-event batches. Measurements
+exclude writes, startup and UI rendering. Tests collect callback results/errors
+and assert outside Wasm dispatch; corruption must fail the named test even when
+unhandled errors are ignored. Array tests preserve descriptors and sharing without
+depending on wall-clock thresholds.
 
 ## License
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -340,7 +340,7 @@ For more React patterns (selectors, actions, provider), see `packages/react/READ
 
 Single-event updates to an existing string leaf copy only its ancestor path,
 preserving `$cid`, old snapshots and unchanged branch identities. Missing baselines,
-accessor/non-plain paths, tree paths and structural/multi-event batches retain the
+accessor/non-plain paths (including array subclasses), tree paths and structural/multi-event batches retain the
 general Immer path. Ordinary dense arrays copy validated data values directly;
 holes, extra keys, accessors or unusual descriptors retain descriptor copying.
 No getters, iterators or species constructors run during this copy. It remains

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,22 @@
 # Loro Mirror
 
+## Streaming text implementation note
+
+Single-event updates to an existing string leaf copy only that leaf's ancestor
+path instead of using the general Immer draft and descriptor repair pass. Copies
+retain `$cid` descriptors and untouched branch identities; old snapshots remain
+unchanged. Missing baselines, accessor/non-plain paths, tree paths and structural
+or multi-event batches retain the general path. There is no storage or public API
+change. Wide ancestor arrays still require copying; this is not windowed reading.
+
+Run `pnpm build` then `node packages/core/scripts/single-text-event-bench.mjs`
+from the repository root. The synthetic benchmark compares single-text events
+with equivalent batches containing an extra empty text event to force the general
+path (so the control includes that extra event's overhead). It checks equal output,
+warms both paths and alternates order. It measures event application only, not
+end-to-end application performance. The existing event test suite checks real
+Loro edits/imports and includes a non-timing guard against reintroducing drafting.
+
 ## Quick Start
 
 Define a schema and instantiate a `Mirror` with a `LoroDoc`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
         "test:watch": "vitest",
         "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
         "bench:ephemeral": "pnpm build && node --expose-gc ./scripts/ephemeral-bench.mjs",
+        "bench:single-text-event": "pnpm build && node ./scripts/single-text-event-bench.mjs",
         "bench:ignore-unknown-properties": "pnpm build && node --expose-gc ./scripts/ignore-unknown-properties-bench.mjs"
     },
     "keywords": [

--- a/packages/core/scripts/single-text-event-bench.mjs
+++ b/packages/core/scripts/single-text-event-bench.mjs
@@ -1,0 +1,76 @@
+// Build first, then: node packages/core/scripts/single-text-event-bench.mjs
+// This measures event-to-state application, not writes, UI latency or startup.
+import assert from "node:assert/strict";
+import { performance } from "node:perf_hooks";
+import loro from "loro-crdt";
+import { Mirror } from "../dist/index.js";
+import { applyEventBatchToState } from "../dist/core/loroEventApply.js";
+
+const { LoroDoc, LoroMap, LoroText } = loro;
+const median = (values) => values.sort((a, b) => a - b)[2];
+for (const size of [200, 1000]) {
+    const doc = new LoroDoc();
+    const rows = doc.getList("rows");
+    let text;
+    for (let i = 0; i < size; i++) {
+        const row = rows.pushContainer(new LoroMap());
+        text = row.setContainer("body", new LoroText());
+        text.update("seed");
+        row.set("payload", { description: "synthetic", values: [1, 2, 3] });
+    }
+    doc.commit();
+    const mirror = new Mirror({ doc });
+    const initial = mirror.getState();
+    mirror.dispose();
+    const batches = [];
+    const unsubscribe = doc.subscribe((batch) => batches.push(batch));
+    for (let i = 0; i < 100; i++) {
+        text.insert(text.length, "x");
+        doc.commit();
+    }
+    unsubscribe();
+    const controls = batches.map((batch) => {
+        assert.equal(batch.events.length, 1);
+        assert.equal(batch.events[0].diff.type, "text");
+        // Same net delta, plus an empty text event to force the general path.
+        return {
+            ...batch,
+            events: [
+                ...batch.events,
+                {
+                    ...batch.events[0],
+                    diff: { type: "text", diff: [] },
+                },
+            ],
+        };
+    });
+    const run = (events) => {
+        let state = initial;
+        const start = performance.now();
+        for (const batch of events)
+            state = applyEventBatchToState(state, batch);
+        const msPerChunk = (performance.now() - start) / events.length;
+        assert.deepEqual(state, doc.toJSON());
+        return msPerChunk;
+    };
+    run(batches);
+    run(controls);
+    const fast = [],
+        general = [];
+    for (let i = 0; i < 5; i++) {
+        if (i % 2) {
+            general.push(run(controls));
+            fast.push(run(batches));
+        } else {
+            fast.push(run(batches));
+            general.push(run(controls));
+        }
+    }
+    console.log(
+        JSON.stringify({
+            size,
+            fastMs: median(fast),
+            generalMs: median(general),
+        }),
+    );
+}

--- a/packages/core/scripts/single-text-event-bench.mjs
+++ b/packages/core/scripts/single-text-event-bench.mjs
@@ -7,8 +7,18 @@ import { Mirror } from "../dist/index.js";
 import { applyEventBatchToState } from "../dist/core/loroEventApply.js";
 
 const { LoroDoc, LoroMap, LoroText } = loro;
-const median = (values) => values.sort((a, b) => a - b)[2];
-for (const size of [200, 1000]) {
+const median = (values) => {
+    const sorted = [...values].sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+    return sorted.length % 2
+        ? sorted[middle]
+        : (sorted[middle - 1] + sorted[middle]) / 2;
+};
+// Optional module URL for a previously built event applier; same events, no noop.
+const baseline = process.env.TEXT_EVENT_BASELINE
+    ? (await import(process.env.TEXT_EVENT_BASELINE)).applyEventBatchToState
+    : undefined;
+for (const size of [1000, 5000, 20000]) {
     const doc = new LoroDoc();
     const rows = doc.getList("rows");
     let text;
@@ -24,7 +34,7 @@ for (const size of [200, 1000]) {
     mirror.dispose();
     const batches = [];
     const unsubscribe = doc.subscribe((batch) => batches.push(batch));
-    for (let i = 0; i < 100; i++) {
+    for (let i = 0; i < 30; i++) {
         text.insert(text.length, "x");
         doc.commit();
     }
@@ -44,25 +54,28 @@ for (const size of [200, 1000]) {
             ],
         };
     });
-    const run = (events) => {
+    const run = (events, apply = applyEventBatchToState) => {
         let state = initial;
         const start = performance.now();
-        for (const batch of events)
-            state = applyEventBatchToState(state, batch);
+        for (const batch of events) state = apply(state, batch);
         const msPerChunk = (performance.now() - start) / events.length;
         assert.deepEqual(state, doc.toJSON());
         return msPerChunk;
     };
     run(batches);
     run(controls);
+    if (baseline) run(batches, baseline);
     const fast = [],
-        general = [];
+        general = [],
+        previous = [];
     for (let i = 0; i < 5; i++) {
         if (i % 2) {
             general.push(run(controls));
+            if (baseline) previous.push(run(batches, baseline));
             fast.push(run(batches));
         } else {
             fast.push(run(batches));
+            if (baseline) previous.push(run(batches, baseline));
             general.push(run(controls));
         }
     }
@@ -71,6 +84,7 @@ for (const size of [200, 1000]) {
             size,
             fastMs: median(fast),
             generalMs: median(general),
+            ...(baseline ? { previousMs: median(previous) } : {}),
         }),
     );
 }

--- a/packages/core/src/core/loroEventApply.test.ts
+++ b/packages/core/src/core/loroEventApply.test.ts
@@ -107,7 +107,29 @@ describe("applyEventBatchToState (inline)", () => {
                 0: { ...descriptors[0], value: after.rows[0] },
             });
             expect(Object.getOwnPropertyDescriptors(rows)).toEqual(descriptors);
-            expect(Object.getPrototypeOf(after.rows)).toBe(Array.prototype);
+            if (kind === "subclass") {
+                const event = batch!.events[0];
+                // Force the general path with an equivalent empty text event.
+                const general = applyEventBatchToState(before, {
+                    ...batch!,
+                    events: [
+                        ...batch!.events,
+                        { ...event, diff: { type: "text", diff: [] } },
+                    ],
+                });
+                expect(Object.getPrototypeOf(after.rows)).toBe(
+                    Object.getPrototypeOf(rows),
+                );
+                expect(Object.getPrototypeOf(after.rows)).toBe(
+                    Object.getPrototypeOf(general.rows),
+                );
+                expect(Object.getOwnPropertyDescriptors(after.rows)).toEqual(
+                    Object.getOwnPropertyDescriptors(general.rows),
+                );
+                expect(after.rows[1]).toBe(rows[1]);
+            } else {
+                expect(Object.getPrototypeOf(after.rows)).toBe(Array.prototype);
+            }
             expect(getterReads).toBe(0);
         },
     );

--- a/packages/core/src/core/loroEventApply.test.ts
+++ b/packages/core/src/core/loroEventApply.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable unicorn/consistent-function-scoping */
 import { describe, it, expect, vi } from "vitest";
 import { LoroDoc, LoroText, LoroList, LoroMap, LoroCounter } from "loro-crdt";
+import type { LoroEventBatch } from "loro-crdt";
 import { applyEventBatchToState } from "./loroEventApply.js";
 import * as immerInstance from "./immer-instance.js";
 import { Mirror } from "./mirror.js";
@@ -11,6 +12,106 @@ const commitAndAssert = (doc: LoroDoc, getState: () => unknown) => {
 };
 
 describe("applyEventBatchToState (inline)", () => {
+    it.each([
+        "dense",
+        "sparse",
+        "extra",
+        "hidden",
+        "symbol",
+        "readonly",
+        "accessor",
+        "length",
+        "subclass",
+    ])(
+        "preserves array descriptors and references for %s ancestors",
+        (kind) => {
+            const doc = new LoroDoc();
+            const text = doc
+                .getList("rows")
+                .pushContainer(new LoroMap())
+                .setContainer("body", new LoroText());
+            text.update("a");
+            doc.commit();
+            let batch: LoroEventBatch | undefined;
+            const unsubscribe = doc.subscribe((event) => {
+                batch = event;
+            });
+            text.update("ab");
+            doc.commit();
+            unsubscribe();
+            expect(batch).toBeDefined();
+            const rows: unknown[] = [{ body: "a" }, { body: "sibling" }];
+            let getterReads = 0;
+            switch (kind) {
+                case "sparse":
+                    Reflect.deleteProperty(rows, "1");
+                    break;
+                case "extra":
+                    Reflect.deleteProperty(rows, "1");
+                    Object.defineProperty(rows, "extra", { value: true });
+                    break;
+                case "hidden":
+                    Object.defineProperty(rows, "hidden", { value: true });
+                    break;
+                case "symbol":
+                    Object.defineProperty(rows, Symbol("meta"), {
+                        value: true,
+                    });
+                    break;
+                case "readonly":
+                    Object.defineProperty(rows, "1", { writable: false });
+                    break;
+                case "accessor":
+                    Object.defineProperty(rows, "1", {
+                        get: () => {
+                            getterReads++;
+                            return "sibling";
+                        },
+                    });
+                    break;
+                case "length":
+                    Object.defineProperty(rows, "length", { writable: false });
+                    break;
+                case "subclass":
+                    Object.setPrototypeOf(
+                        rows,
+                        class extends Array {}.prototype,
+                    );
+                    break;
+            }
+            const descriptors = Object.getOwnPropertyDescriptors(
+                rows as object,
+            );
+            const before = { rows };
+            const defineProperties = vi.spyOn(Object, "defineProperties");
+            let after: typeof before;
+            try {
+                after = applyEventBatchToState(before, batch!);
+                if (kind === "dense") {
+                    expect(
+                        defineProperties.mock.calls.some(([target]) =>
+                            Array.isArray(target),
+                        ),
+                    ).toBe(false);
+                }
+            } finally {
+                defineProperties.mockRestore();
+            }
+            expect(after.rows[0]).toEqual({ body: "ab" });
+            expect(after.rows[0]).not.toBe(rows[0]);
+            expect(Object.getOwnPropertyDescriptor(after.rows, "1")).toEqual(
+                descriptors[1],
+            );
+            expect(Object.getOwnPropertyDescriptors(after.rows)).toEqual({
+                ...descriptors,
+                0: { ...descriptors[0], value: after.rows[0] },
+            });
+            expect(Object.getOwnPropertyDescriptors(rows)).toEqual(descriptors);
+            expect(Object.getPrototypeOf(after.rows)).toBe(Array.prototype);
+            expect(getterReads).toBe(0);
+        },
+    );
+
     it("copies only an existing text path without drafting, preserving snapshots and cid descriptors", () => {
         const doc = new LoroDoc();
         const list = doc.getList("rows");
@@ -54,7 +155,11 @@ describe("applyEventBatchToState (inline)", () => {
     it("matches the general path across local and concurrent imported text edits", () => {
         const doc = new LoroDoc();
         doc.setPeerId("1");
-        const text = doc.getMap("task").setContainer("body", new LoroText());
+        const rows = doc.getMap("task").setContainer("rows", new LoroList());
+        const text = rows
+            .pushContainer(new LoroMap())
+            .setContainer("body", new LoroText());
+        rows.pushContainer(new LoroMap()).set("unchanged", true);
         text.update("seed");
         doc.commit();
         const peer = new LoroDoc();
@@ -62,41 +167,61 @@ describe("applyEventBatchToState (inline)", () => {
         peer.import(doc.export({ mode: "snapshot" }));
         let fast = doc.toJSON();
         let general = doc.toJSON();
+        const observations: {
+            fast: unknown;
+            general: unknown;
+            doc: unknown;
+            old: unknown;
+            oldGeneral: unknown;
+            previous: string;
+        }[] = [];
+        const errors: unknown[] = [];
         const unsub = doc.subscribe((batch) => {
-            const previous = JSON.stringify(fast);
-            const old = fast;
-            fast = applyEventBatchToState(fast, batch, (id) =>
-                doc.getContainerById(id),
-            );
-            const event = batch.events[0];
-            // An extra empty text delta forces the unchanged general batch path.
-            const control =
-                batch.events.length === 1 && event.diff.type === "text"
-                    ? {
-                          ...batch,
-                          events: [
-                              ...batch.events,
-                              {
-                                  ...event,
-                                  diff: { type: "text" as const, diff: [] },
-                              },
-                          ],
-                      }
-                    : batch;
-            general = applyEventBatchToState(general, control, (id) =>
-                doc.getContainerById(id),
-            );
-            expect(fast).toEqual(general);
-            expect(fast).toEqual(doc.toJSON());
-            expect(JSON.stringify(old)).toBe(previous);
+            try {
+                const previous = JSON.stringify(fast);
+                const old = fast;
+                const oldGeneral = general;
+                fast = applyEventBatchToState(fast, batch, (id) =>
+                    doc.getContainerById(id),
+                );
+                const event = batch.events[0];
+                // An extra empty text delta forces the unchanged general batch path.
+                const control =
+                    batch.events.length === 1 && event.diff.type === "text"
+                        ? {
+                              ...batch,
+                              events: [
+                                  ...batch.events,
+                                  {
+                                      ...event,
+                                      diff: { type: "text" as const, diff: [] },
+                                  },
+                              ],
+                          }
+                        : batch;
+                general = applyEventBatchToState(general, control, (id) =>
+                    doc.getContainerById(id),
+                );
+                observations.push({
+                    fast,
+                    general,
+                    doc: doc.toJSON(),
+                    old,
+                    oldGeneral,
+                    previous,
+                });
+            } catch (error) {
+                errors.push(error);
+            }
         });
         try {
             for (let i = 0; i < 50; i++) {
                 text.update(`local ${i} 🦀`);
                 doc.commit();
-                (peer.getMap("task").get("body") as LoroText).update(
-                    `peer ${i} 文本`,
-                );
+                const peerRow = (
+                    peer.getMap("task").get("rows") as LoroList
+                ).get(0) as LoroMap;
+                (peerRow.get("body") as LoroText).update(`peer ${i} 文本`);
                 peer.commit();
                 doc.import(
                     peer.export({ mode: "update", from: doc.version() }),
@@ -115,6 +240,58 @@ describe("applyEventBatchToState (inline)", () => {
             doc.commit();
             doc.getMap("task").delete("extra");
             doc.commit();
+            // Wasm dispatch may turn callback throws into unhandled rejections.
+            // Assert in the test body, including application errors and delivery.
+            expect(errors).toEqual([]);
+            expect(observations.length).toBeGreaterThanOrEqual(100);
+            const assertParity = (
+                a: unknown,
+                b: unknown,
+                oldA: unknown,
+                oldB: unknown,
+            ) => {
+                if (
+                    a === null ||
+                    typeof a !== "object" ||
+                    b === null ||
+                    typeof b !== "object"
+                ) {
+                    expect(a).toEqual(b);
+                    return;
+                }
+                expect(Object.getPrototypeOf(a)).toBe(Object.getPrototypeOf(b));
+                expect(Reflect.ownKeys(a)).toEqual(Reflect.ownKeys(b));
+                expect(a === oldA).toBe(b === oldB);
+                for (const key of Reflect.ownKeys(a)) {
+                    const da = Object.getOwnPropertyDescriptor(a, key)!;
+                    const db = Object.getOwnPropertyDescriptor(b, key)!;
+                    expect({ ...da, value: undefined }).toEqual({
+                        ...db,
+                        value: undefined,
+                    });
+                    assertParity(
+                        da.value,
+                        db.value,
+                        oldA && typeof oldA === "object"
+                            ? Object.getOwnPropertyDescriptor(oldA, key)?.value
+                            : undefined,
+                        oldB && typeof oldB === "object"
+                            ? Object.getOwnPropertyDescriptor(oldB, key)?.value
+                            : undefined,
+                    );
+                }
+            };
+            for (const observed of observations) {
+                assertParity(
+                    observed.fast,
+                    observed.general,
+                    observed.old,
+                    observed.oldGeneral,
+                );
+                expect(observed.fast).toEqual(observed.general);
+                expect(observed.fast).toEqual(observed.doc);
+                expect(JSON.stringify(observed.old)).toBe(observed.previous);
+            }
         } finally {
             unsub();
         }

--- a/packages/core/src/core/loroEventApply.test.ts
+++ b/packages/core/src/core/loroEventApply.test.ts
@@ -1,7 +1,9 @@
 /* eslint-disable unicorn/consistent-function-scoping */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { LoroDoc, LoroText, LoroList, LoroMap, LoroCounter } from "loro-crdt";
 import { applyEventBatchToState } from "./loroEventApply.js";
+import * as immerInstance from "./immer-instance.js";
+import { Mirror } from "./mirror.js";
 
 const commitAndAssert = (doc: LoroDoc, getState: () => unknown) => {
     doc.commit();
@@ -9,6 +11,115 @@ const commitAndAssert = (doc: LoroDoc, getState: () => unknown) => {
 };
 
 describe("applyEventBatchToState (inline)", () => {
+    it("copies only an existing text path without drafting, preserving snapshots and cid descriptors", () => {
+        const doc = new LoroDoc();
+        const list = doc.getList("rows");
+        const row = list.pushContainer(new LoroMap());
+        const text = row.setContainer("text", new LoroText());
+        text.update("hello");
+        list.pushContainer(new LoroMap()).set("untouched", true);
+        doc.commit();
+        const mirror = new Mirror({ doc });
+        const before = mirror.getState() as { rows: { text: string }[] };
+        const descriptor = Object.getOwnPropertyDescriptor(
+            before.rows[0],
+            "$cid",
+        );
+        expect(descriptor).toMatchObject({
+            enumerable: false,
+            writable: false,
+        });
+        const produce = vi.spyOn(immerInstance, "produce");
+        try {
+            text.insert(5, " world");
+            doc.commit();
+            const after = mirror.getState() as typeof before;
+            expect(after.rows[0].text).toBe("hello world");
+            expect(before.rows[0].text).toBe("hello");
+            expect(after.rows).not.toBe(before.rows);
+            expect(after.rows[0]).not.toBe(before.rows[0]);
+            expect(after.rows[1]).toBe(before.rows[1]);
+            expect(
+                Object.getOwnPropertyDescriptor(after.rows[0], "$cid"),
+            ).toEqual(descriptor);
+            // Deterministic work guard: disabling the fast path must fail this test,
+            // even if the resulting JSON is still correct. No timing threshold.
+            expect(produce).not.toHaveBeenCalled();
+        } finally {
+            produce.mockRestore();
+            mirror.dispose();
+        }
+    });
+
+    it("matches the general path across local and concurrent imported text edits", () => {
+        const doc = new LoroDoc();
+        doc.setPeerId("1");
+        const text = doc.getMap("task").setContainer("body", new LoroText());
+        text.update("seed");
+        doc.commit();
+        const peer = new LoroDoc();
+        peer.setPeerId("2");
+        peer.import(doc.export({ mode: "snapshot" }));
+        let fast = doc.toJSON();
+        let general = doc.toJSON();
+        const unsub = doc.subscribe((batch) => {
+            const previous = JSON.stringify(fast);
+            const old = fast;
+            fast = applyEventBatchToState(fast, batch, (id) =>
+                doc.getContainerById(id),
+            );
+            const event = batch.events[0];
+            // An extra empty text delta forces the unchanged general batch path.
+            const control =
+                batch.events.length === 1 && event.diff.type === "text"
+                    ? {
+                          ...batch,
+                          events: [
+                              ...batch.events,
+                              {
+                                  ...event,
+                                  diff: { type: "text" as const, diff: [] },
+                              },
+                          ],
+                      }
+                    : batch;
+            general = applyEventBatchToState(general, control, (id) =>
+                doc.getContainerById(id),
+            );
+            expect(fast).toEqual(general);
+            expect(fast).toEqual(doc.toJSON());
+            expect(JSON.stringify(old)).toBe(previous);
+        });
+        try {
+            for (let i = 0; i < 50; i++) {
+                text.update(`local ${i} 🦀`);
+                doc.commit();
+                (peer.getMap("task").get("body") as LoroText).update(
+                    `peer ${i} 文本`,
+                );
+                peer.commit();
+                doc.import(
+                    peer.export({ mode: "update", from: doc.version() }),
+                );
+                peer.import(
+                    doc.export({ mode: "update", from: peer.version() }),
+                );
+                expect(peer.toJSON()).toEqual(doc.toJSON());
+            }
+            // Structural and mixed batches must still initialize/delete correctly.
+            const extra = doc
+                .getMap("task")
+                .setContainer("extra", new LoroText());
+            extra.update("new");
+            text.update("final");
+            doc.commit();
+            doc.getMap("task").delete("extra");
+            doc.commit();
+        } finally {
+            unsub();
+        }
+    });
+
     it("syncs map primitives", () => {
         const doc = new LoroDoc();
         let state: Record<string, unknown> = {};

--- a/packages/core/src/core/loroEventApply.ts
+++ b/packages/core/src/core/loroEventApply.ts
@@ -106,6 +106,7 @@ function applySingleTextEvent<T extends object>(
         if (node === null || typeof node !== "object") return undefined;
         if (Array.isArray(node)) {
             if (
+                Object.getPrototypeOf(node) !== Array.prototype ||
                 typeof key !== "number" ||
                 !Number.isInteger(key) ||
                 key < 0 ||
@@ -156,7 +157,6 @@ function applySingleTextEvent<T extends object>(
  */
 function copyDenseArray(parent: unknown[]): unknown[] | undefined {
     if (
-        Object.getPrototypeOf(parent) !== Array.prototype ||
         Reflect.ownKeys(parent).length !== parent.length + 1 ||
         !Object.getOwnPropertyDescriptor(parent, "length")?.writable
     )

--- a/packages/core/src/core/loroEventApply.ts
+++ b/packages/core/src/core/loroEventApply.ts
@@ -8,10 +8,7 @@ import {
     LoroEventBatch,
     TreeID,
 } from "loro-crdt";
-import {
-    normalizeTreeJson,
-    type NormalizedTreeNode,
-} from "./tree-utils.js";
+import { normalizeTreeJson, type NormalizedTreeNode } from "./tree-utils.js";
 import {
     defineCidProperty,
     hardenCidDescriptors,
@@ -65,6 +62,8 @@ export function applyEventBatchToState<T extends object>(
               ) => SchemaType | undefined;
           },
 ): T {
+    const textState = applySingleTextEvent(currentState, event);
+    if (textState !== undefined) return textState;
     const opts =
         typeof options === "function"
             ? { getContainerById: options }
@@ -88,6 +87,60 @@ export function applyEventBatchToState<T extends object>(
     // them before the state is published.
     hardenCidDescriptors(next, currentState);
     return next;
+}
+
+/** Copy only the ancestors of an existing text leaf, retaining descriptors and
+ * untouched branches. Other batches keep the general Immer path below.
+ */
+function applySingleTextEvent<T extends object>(
+    state: T,
+    batch: LoroEventBatch,
+): T | undefined {
+    if (batch.events.length !== 1) return undefined;
+    const event = batch.events[0];
+    if (!event || event.diff.type !== "text" || !event.path?.length)
+        return undefined;
+    const parents: { node: object; key: string | number }[] = [];
+    let node: unknown = state;
+    for (const key of event.path) {
+        if (node === null || typeof node !== "object") return undefined;
+        if (Array.isArray(node)) {
+            if (
+                typeof key !== "number" ||
+                !Number.isInteger(key) ||
+                key < 0 ||
+                key >= node.length
+            )
+                return undefined;
+        } else {
+            const proto = Object.getPrototypeOf(node);
+            if (
+                (proto !== Object.prototype && proto !== null) ||
+                typeof key !== "string" ||
+                key === "__proto__" ||
+                key === "constructor" ||
+                key === "prototype" ||
+                key === "$cid"
+            )
+                return undefined;
+        }
+        const descriptor = Object.getOwnPropertyDescriptor(node, key);
+        if (!descriptor || !("value" in descriptor)) return undefined;
+        parents.push({ node, key });
+        node = descriptor.value;
+    }
+    if (typeof node !== "string") return undefined;
+    let next: unknown = applyTextDelta(node, event.diff.diff);
+    if (next === node) return state;
+    for (let i = parents.length - 1; i >= 0; i--) {
+        const { node: parent, key } = parents[i];
+        const descriptors = Object.getOwnPropertyDescriptors(parent);
+        descriptors[key] = { ...descriptors[key], value: next };
+        next = Array.isArray(parent)
+            ? Object.defineProperties([], descriptors)
+            : Object.create(Object.getPrototypeOf(parent), descriptors);
+    }
+    return next as T;
 }
 
 /**

--- a/packages/core/src/core/loroEventApply.ts
+++ b/packages/core/src/core/loroEventApply.ts
@@ -134,6 +134,14 @@ function applySingleTextEvent<T extends object>(
     if (next === node) return state;
     for (let i = parents.length - 1; i >= 0; i--) {
         const { node: parent, key } = parents[i];
+        const arrayCopy = Array.isArray(parent)
+            ? copyDenseArray(parent)
+            : undefined;
+        if (arrayCopy) {
+            arrayCopy[key as number] = next;
+            next = arrayCopy;
+            continue;
+        }
         const descriptors = Object.getOwnPropertyDescriptors(parent);
         descriptors[key] = { ...descriptors[key], value: next };
         next = Array.isArray(parent)
@@ -141,6 +149,34 @@ function applySingleTextEvent<T extends object>(
             : Object.create(Object.getPrototypeOf(parent), descriptors);
     }
     return next as T;
+}
+
+/** Avoid defineProperties for ordinary dense arrays, without invoking getters,
+ * iterators or slice's species constructor. Unusual descriptors use the old copy.
+ */
+function copyDenseArray(parent: unknown[]): unknown[] | undefined {
+    if (
+        Object.getPrototypeOf(parent) !== Array.prototype ||
+        Reflect.ownKeys(parent).length !== parent.length + 1 ||
+        !Object.getOwnPropertyDescriptor(parent, "length")?.writable
+    )
+        return undefined;
+    // Preallocate without Array.from callbacks/iterators on this hot path.
+    // eslint-disable-next-line unicorn/no-new-array
+    const copy = new Array<unknown>(parent.length);
+    for (let i = 0; i < parent.length; i++) {
+        const descriptor = Object.getOwnPropertyDescriptor(parent, i);
+        if (
+            !descriptor ||
+            !("value" in descriptor) ||
+            !descriptor.writable ||
+            !descriptor.enumerable ||
+            !descriptor.configurable
+        )
+            return undefined;
+        copy[i] = descriptor.value;
+    }
+    return copy;
 }
 
 /**


### PR DESCRIPTION
## Summary

Upstream the single-text-event reader optimization used by [Lody PR #460](https://github.com/LodyAI/Lody/pull/460). Copy an existing string leaf and its ancestor path instead of using the general Immer draft and descriptor repair pass. Preserve `$cid`, old snapshots, property descriptors and untouched branch identities.

Dense ordinary arrays now copy descriptor-validated values directly. Prototype, own-key count, length writability and every index descriptor are checked; sparse arrays, extra keys, accessors and special descriptors retain the previous descriptor copy. This avoids getter, iterator and species-constructor behavior rather than calling slice blindly.

No public API, schema, CRDT storage or write-validation change. Missing text baselines, accessor/non-plain paths, tree paths and structural/multi-event batches still use the general implementation.

## Visual explanation

```mermaid
flowchart TD
 A[Loro event batch] --> B{Single existing text leaf?}
 B -->|No| C[General Immer event path]
 B -->|Yes| D[Apply text delta and copy ancestors]
 D --> E{Ordinary dense array ancestor?}
 E -->|Yes| F[Validate descriptors and copy values]
 E -->|No| G[Preserve full descriptors]
 C --> H[New read snapshot]
 F --> H
 G --> H
```

## Verification

Node 22.23.1, pnpm 9.15.9, frozen lockfile. `pnpm check` passes: build, 533 tests across 44 files, lint with 12 warnings and zero errors, and typecheck. Changed files formatted; no dependency version change.

- Real Mirror text/snapshot/sibling/`$cid` assertions plus deterministic no-drafting guard.
- 50 rounds of two-peer edits/imports compare values, own keys, descriptors, prototypes and structural-sharing parity against the general event path, including Unicode and mixed structural batches.
- All differential assertions run outside Wasm callbacks; callback errors are collected and asserted in the test body.
- Mutation: appending `CORRUPT` fails the named differential test even with `--dangerouslyIgnoreUnhandledErrors`. Removing dense copying fails its named work guard. Both restored tests pass.
- Nine array cases: dense, sparse, hole-plus-extra-key, hidden key, symbol key, readonly index, accessor, locked length and subclass. Check descriptors, unchanged input and sibling references, and no getter invocation.

## Performance

Run `pnpm --filter loro-mirror bench:single-text-event`. Optional `TEXT_EVENT_BASELINE` is a module URL exporting a previously built `applyEventBatchToState`.

Below: three fresh Node processes; each warms up and alternates five samples of 30 events. Median of process medians, milliseconds per single text event. The previous implementation is the exact PR version at `307643e`, applied to identical event batches.

| Synthetic rows | Previous PR | Current | Additional speedup |
| --- | ---: | ---: | ---: |
| 1,000 | 0.204 | 0.051 | 4.0x |
| 5,000 | 1.085 | 0.275 | 3.9x |
| 20,000 | 4.639 | 1.288 | 3.6x |

Current results across the three processes: 0.0509–0.0526, 0.2709–0.2872, and 1.2669–1.3338 ms respectively. Output equality is asserted. The script also measures a general-path control with one extra empty text event; that control includes the extra-event overhead and is not an exact main-branch baseline.

This measures event application only, excluding writes, startup, UI and network. Array traversal/copying remains O(width), not windowed reading. No overall application or 3000-round acceptance claim.

## Scope and review focus

Independent of Ignore (#97), initialization (#98), and LazyList (#96). Please challenge descriptor/snapshot parity, fallback boundaries and composition with those changes. Lody retains its patch until an upstream release is adopted. No merge, release or downstream dependency update is included.