### PR TITLE
fix(core): preserve nested Ignore and lazy schema boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,8 @@
 Bulk initialization prefers optional `LoroDoc.toContainerTree()` when available. Its
 `Value` nodes are opaque, including embedded objects with `type/cid/value` fields.
 Carry the format flag in each walk context; never infer it from child value shape.
-Older packages continue through verified deep-value or handle reads. Tree projection
-retains its existing normalization path. Tests must disable both bulk APIs when
+Older packages continue through verified deep-value or handle reads. Typed trees read node data through the schema-aware container reader; untyped trees
+retain JSON normalization. Tests must disable both bulk APIs when
 explicitly comparing with the legacy handle path.
 The container-tree path selects required roots before materialization, excluding
 explicit Ignore roots. Preserve unknown roots according to ignoreUnknownProperties.
@@ -89,3 +89,9 @@ Lazy slots preserve container provenance from real handles independently of thei
 id strings. A literal string, including one equal to a live container id, stays
 opaque. Resolve ambiguous shallow map fields through map.get(field), not by
 looking up the string as an id elsewhere in the document.
+
+Nested Ignore fields are omitted on initial reads and filtered inside parent Map
+diffs as well as container-targeted events; mixed batches retain normal fields.
+Lazy write guards traverse eager lists, map records and tree data, matching
+surviving list items by container ID and tree nodes by node ID across reordering.
+Typed tree reads must not materialize nested lazy bodies through toJSON.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,3 +95,6 @@ diffs as well as container-targeted events; mixed batches retain normal fields.
 Lazy write guards traverse eager lists, map records and tree data, matching
 surviving list items by container ID and tree nodes by node ID across reordering.
 Typed tree reads must not materialize nested lazy bodies through toJSON.
+New list rows without a container ID are insertions, never positional matches
+for lazy-view write guards. Newly initialized map fields declared lazy must
+publish LazyList views after their document containers have been created.

--- a/packages/core/src/core/mirror.ts
+++ b/packages/core/src/core/mirror.ts
@@ -76,7 +76,6 @@ import {
     stripUndefined,
     applyDecode,
     applyEncode,
-    decodeNestedJsonValues,
     safeStringify,
     cidsEqual,
     tryUpdateToContainer,
@@ -925,6 +924,11 @@ export class Mirror<S extends SchemaType> {
                 const map = container as LoroMap;
                 const context = this.getChildRegistrationContext(container);
                 for (const key of map.keys()) {
+                    if (
+                        getChildSchema(context.parentSchema, key)?.type ===
+                        "ignore"
+                    )
+                        continue;
                     const value = map.get(key);
                     if (isContainer(value)) {
                         this.registerChildContainer(
@@ -1055,10 +1059,38 @@ export class Mirror<S extends SchemaType> {
             }
             return rootKeyByCid;
         };
-        const events = event.events.filter(
-            (e) => !this.isIgnoredEvent(e, getRootKeyByCid),
-        );
-        if (events.length === event.events.length) return event;
+        let changed = false;
+        const events: LoroEventBatch["events"] = [];
+        for (const e of event.events) {
+            if (this.isIgnoredEvent(e, getRootKeyByCid)) {
+                changed = true;
+                continue;
+            }
+            if (this.hasNestedIgnoreFields && e.diff.type === "map") {
+                let targetSchema: SchemaType | undefined = this.schema;
+                for (const key of e.path)
+                    targetSchema = getChildSchema(targetSchema, key);
+                const entries = Object.entries(e.diff.updated);
+                const kept = entries.filter(
+                    ([key]) =>
+                        getChildSchema(targetSchema, key)?.type !== "ignore",
+                );
+                if (kept.length !== entries.length) {
+                    changed = true;
+                    if (kept.length)
+                        events.push({
+                            ...e,
+                            diff: {
+                                ...e.diff,
+                                updated: Object.fromEntries(kept),
+                            },
+                        });
+                    continue;
+                }
+            }
+            events.push(e);
+        }
+        if (!changed) return event;
         return { ...event, events } as LoroEventBatch;
     }
 
@@ -3122,6 +3154,7 @@ export class Mirror<S extends SchemaType> {
                 : undefined;
             defineCidProperty(obj, c.id);
             for (const k of m.keys()) {
+                if (getChildSchema(schema, k)?.type === "ignore") continue;
                 const v = m.get(k);
                 if (isContainer(v)) {
                     if (childRegistrationContext) {
@@ -3185,56 +3218,19 @@ export class Mirror<S extends SchemaType> {
             if (options.registerContainers) {
                 this.registerNestedContainers(c);
             }
+            if (schema && isLoroTreeSchema(schema)) {
+                const readNodes = (
+                    nodes: ReturnType<LoroTree["roots"]>,
+                ): MirrorState[] =>
+                    nodes.map((node) => ({
+                        id: node.id,
+                        data: this.containerToMirrorState(node.data, options),
+                        children: readNodes(node.children() ?? []),
+                    }));
+                return readNodes(t.roots());
+            }
             // Normalize via toJSON first
             const normalized = normalizeTreeJsonForMirror(t.toJSON());
-            // Optionally inject $cid per node.data using an id->cid map from live nodes
-            const schema = this.getContainerSchema(t.id);
-            const withCid = schema && isLoroTreeSchema(schema);
-            if (withCid) {
-                const idToCid = new Map<string, string>();
-                // Best-effort: collect from runtime nodes if API available
-                const tMaybe = t as unknown as { getNodes?: () => unknown[] };
-                const nodes: unknown[] = tMaybe.getNodes?.() ?? [];
-                for (const raw of nodes) {
-                    try {
-                        const n = raw as { id?: unknown; data?: unknown };
-                        const id = typeof n.id === "string" ? n.id : undefined;
-                        let dataId: string | undefined;
-                        if (n.data && typeof n.data === "object") {
-                            const d = n.data as { id?: unknown };
-                            dataId =
-                                typeof d.id === "string" ? d.id : undefined;
-                        }
-                        if (id && dataId) idToCid.set(id, dataId);
-                    } catch {
-                        // ignore
-                    }
-                }
-                const stamp = (arr: unknown[]) => {
-                    for (const node of arr) {
-                        const n = node as {
-                            id: unknown;
-                            data?: unknown;
-                            children?: unknown;
-                        };
-                        const cid =
-                            typeof n.id === "string"
-                                ? idToCid.get(n.id)
-                                : undefined;
-                        if (cid) {
-                            if (!n.data || typeof n.data !== "object") {
-                                (n as { data: Record<string, unknown> }).data =
-                                    {};
-                            }
-                            defineCidProperty(n.data, cid as ContainerID);
-                        }
-                        if (Array.isArray(n.children))
-                            stamp(n.children as unknown[]);
-                    }
-                };
-                stamp(normalized);
-                decodeNestedJsonValues(normalized, schema);
-            }
             return normalized as unknown as MirrorState;
         }
         // Fallback
@@ -3646,6 +3642,7 @@ export class Mirror<S extends SchemaType> {
                 const fresh: MirrorStateObject = {};
                 defineCidProperty(fresh, cid);
                 for (const k of Object.keys(obj)) {
+                    if (getChildSchema(schema, k)?.type === "ignore") continue;
                     fresh[k] = this.bulkChildState(
                         cid,
                         "Map",
@@ -3664,6 +3661,10 @@ export class Mirror<S extends SchemaType> {
         // directly as state.
         defineCidProperty(obj, cid);
         for (const k of Object.keys(obj)) {
+            if (getChildSchema(schema, k)?.type === "ignore") {
+                delete obj[k];
+                continue;
+            }
             obj[k] = this.bulkChildState(
                 cid,
                 "Map",
@@ -4506,50 +4507,73 @@ export class Mirror<S extends SchemaType> {
     ): void {
         if (!this.schemaHasLazyList || oldState === newState) return;
         if (!this.schema || this.schema.type !== "schema") return;
-        const rootSchema = this.schema as RootSchemaType<
-            Record<string, ContainerSchemaType>
-        >;
-        this.assertLazyInMapDefinition(
-            rootSchema.definition,
-            oldState,
-            newState,
-            "",
-        );
+        this.assertLazyUntouched(this.schema, oldState, newState, "");
     }
 
-    private assertLazyInMapDefinition(
-        definition: Record<string, SchemaType>,
-        oldObj: unknown,
-        newObj: unknown,
+    private assertLazyUntouched(
+        fieldSchema: SchemaType,
+        oldValue: unknown,
+        newValue: unknown,
         path: string,
     ): void {
-        if (oldObj === newObj) return;
-        if (!isObject(oldObj) || !isObject(newObj)) return;
-        for (const key of Object.keys(definition)) {
-            const fieldSchema = definition[key];
-            const oldVal = oldObj[key];
-            const newVal = newObj[key];
-            if (oldVal === newVal) continue;
-            const fieldPath = path ? `${path}.${key}` : key;
-            if (isLazyListSchema(fieldSchema)) {
-                // Only throw when there was a LazyList to lose: if the slot
-                // never held one (schema drift), let the normal flow proceed.
-                if (isLazyList(oldVal)) {
-                    throw new LazyListWriteError(fieldPath);
+        if (oldValue === newValue) return;
+        if (isLazyListSchema(fieldSchema)) {
+            if (isLazyList(oldValue)) throw new LazyListWriteError(path);
+            return;
+        }
+        // Removing a parent is allowed. Only surviving containers need their
+        // existing lazy views preserved; match identities across reordering.
+        if (Array.isArray(oldValue) && Array.isArray(newValue)) {
+            const tree = isLoroTreeSchema(fieldSchema);
+            const identity = (value: unknown): unknown =>
+                isObject(value) ? value[tree ? "id" : CID_KEY] : undefined;
+            const previous = new Map(
+                oldValue.map((value) => [identity(value), value]),
+            );
+            for (let i = 0; i < newValue.length; i++) {
+                const next = newValue[i];
+                const id = identity(next);
+                const old = id === undefined ? oldValue[i] : previous.get(id);
+                if (tree) {
+                    if (!isObject(old) || !isObject(next)) continue;
+                    this.assertLazyUntouched(
+                        fieldSchema.nodeSchema,
+                        old.data,
+                        next.data,
+                        `${path}[${i}].data`,
+                    );
+                    this.assertLazyUntouched(
+                        fieldSchema,
+                        old.children,
+                        next.children,
+                        `${path}[${i}].children`,
+                    );
+                } else {
+                    const child = getChildSchema(fieldSchema, i);
+                    if (child)
+                        this.assertLazyUntouched(
+                            child,
+                            old,
+                            next,
+                            `${path}[${i}]`,
+                        );
                 }
-                continue;
             }
-            if (isLoroMapSchema(fieldSchema)) {
-                this.assertLazyInMapDefinition(
-                    fieldSchema.definition as Record<string, SchemaType>,
-                    oldVal,
-                    newVal,
-                    fieldPath,
+            return;
+        }
+        if (!isObject(oldValue) || !isObject(newValue)) return;
+        for (const key of new Set([
+            ...Object.keys(oldValue),
+            ...Object.keys(newValue),
+        ])) {
+            const child = getChildSchema(fieldSchema, key);
+            if (child)
+                this.assertLazyUntouched(
+                    child,
+                    oldValue[key],
+                    newValue[key],
+                    path ? `${path}.${key}` : key,
                 );
-            }
-            // Lazy lists nested under (non-lazy) list items or tree nodes are
-            // not guarded: positional paths shift under legitimate edits, so
-            // a reference check could false-positive. Documented best-effort.
         }
     }
 

--- a/packages/core/src/core/mirror.ts
+++ b/packages/core/src/core/mirror.ts
@@ -2402,12 +2402,20 @@ export class Mirror<S extends SchemaType> {
                     if (fieldSchema && isContainerSchema(fieldSchema)) {
                         const ct = schemaToContainerType(fieldSchema);
                         if (ct && isValueOfContainerType(ct, val)) {
-                            this.insertContainerIntoMap(
+                            const inserted = this.insertContainerIntoMap(
                                 map,
                                 fieldSchema,
                                 key,
                                 val,
                             );
+                            // Pending state is also the published read state.
+                            // Replace only this newly constructed lazy slot;
+                            // unchanged rows and their views retain identity.
+                            if (isLazyListSchema(fieldSchema)) {
+                                value[key] = this.getOrCreateLazyList(
+                                    inserted.id,
+                                );
+                            }
                         } else {
                             // Schema says container but value doesn't match - fall back to primitive
                             map.set(key, applyEncode(fieldSchema, val));
@@ -4533,7 +4541,10 @@ export class Mirror<S extends SchemaType> {
             for (let i = 0; i < newValue.length; i++) {
                 const next = newValue[i];
                 const id = identity(next);
-                const old = id === undefined ? oldValue[i] : previous.get(id);
+                // Unattached inputs are insertions, not replacements of the
+                // old row at this position. Existing map views always carry a CID.
+                if (id === undefined) continue;
+                const old = previous.get(id);
                 if (tree) {
                     if (!isObject(old) || !isObject(next)) continue;
                     this.assertLazyUntouched(

--- a/packages/core/tests/container-tree-init.test.ts
+++ b/packages/core/tests/container-tree-init.test.ts
@@ -98,10 +98,7 @@ it.each([false, true])(
             doc,
             schema: schema({
                 root: schema.LoroMapRecord(schema.Any()),
-                // Root Ignore is supported at runtime; the existing root schema type excludes it.
-                history: schema.Ignore() as unknown as ReturnType<
-                    typeof schema.LoroMapRecord
-                >,
+                history: schema.Ignore(),
             }),
             ignoreUnknownProperties: keepUnknown,
         });

--- a/packages/core/tests/nested-schema-boundaries.test.ts
+++ b/packages/core/tests/nested-schema-boundaries.test.ts
@@ -268,3 +268,60 @@ it("guards lazy fields under map records before any sibling is written", () => {
     expect(doc.toJSON()).toEqual(before);
     expect(isLazyList(m.getState().rows.a.items)).toBe(true);
 });
+
+for (const movable of [false, true]) {
+    for (const index of [0, 1, 3]) {
+        it(`accepts ${movable ? "movable" : "ordinary"} insertion at ${index} and exposes lazy children`, async () => {
+            const doc = new LoroDoc();
+            const rows = movable
+                ? doc.getMovableList("rows")
+                : doc.getList("rows");
+            for (const id of ["a", "b", "c"]) {
+                const row = rows.insertContainer(rows.length, new LoroMap());
+                row.set("id", id);
+                row.setContainer("items", new LoroList()).push(id);
+            }
+            doc.commit();
+            const item = schema.LoroMap({
+                id: schema.String(),
+                items: schema.LoroList(schema.String(), undefined, {
+                    lazy: { index: [] },
+                }),
+            });
+            const m = new Mirror({
+                doc,
+                schema: schema({
+                    rows: movable
+                        ? schema.LoroMovableList(item, (x) => x.id)
+                        : schema.LoroList(item, (x) => x.id),
+                }),
+            });
+            const previous = m.getState().rows.map((row) => row.items);
+            m.setState((d) => {
+                d.rows.splice(index, 0, {
+                    id: "new",
+                    items: ["body"],
+                } as unknown as (typeof d.rows)[number]);
+            });
+            const state = m.getState().rows;
+            const expected = ["a", "b", "c"];
+            expected.splice(index, 0, "new");
+            expect(state.map((row) => row.id)).toEqual(expected);
+            expect(isLazyList(state[index].items)).toBe(true);
+            await state[index].items.hydrate(0, 1);
+            expect(state[index].items.get(0)).toBe("body");
+            state
+                .filter((row) => row.id !== "new")
+                .forEach((row, i) => {
+                    expect(row.items).toBe(previous[i]);
+                });
+            expect(rows.length).toBe(4);
+            expect(() => {
+                m.setState((d) => {
+                    Object.assign(d.rows[index], { items: [] });
+                });
+            }).toThrow(LazyListWriteError);
+            m.dispose();
+        });
+    }
+}

--- a/packages/core/tests/nested-schema-boundaries.test.ts
+++ b/packages/core/tests/nested-schema-boundaries.test.ts
@@ -1,0 +1,270 @@
+import { expect, it } from "vitest";
+import { LoroDoc, LoroList, LoroMap } from "loro-crdt";
+import {
+    Mirror,
+    schema,
+    isLazyList,
+    LazyListWriteError,
+} from "../src/index.js";
+
+it("keeps scalar Ignore out of initial and event state", () => {
+    const doc = new LoroDoc();
+    const map = doc.getMap("session");
+    map.set("name", "old");
+    map.set("cache", 1);
+    doc.commit();
+    const mirror = new Mirror({
+        doc,
+        schema: schema({
+            session: schema.LoroMap({
+                name: schema.String(),
+                cache: schema.Ignore(),
+            }),
+        }),
+    });
+    const initial = mirror.getState().session.cache;
+    map.set("cache", 42);
+    map.set("name", "new");
+    doc.commit();
+    expect(mirror.getState().session.name).toBe("new");
+    expect(initial).toBeUndefined();
+    expect(mirror.getState().session.cache).toBeUndefined();
+});
+
+it("rejects replacing a lazy view under an eager item before writing", () => {
+    const doc = new LoroDoc();
+    const row = doc.getList("rows").insertContainer(0, new LoroMap());
+    row.set("id", "row");
+    row.setContainer("items", new LoroList()).push("old");
+    doc.commit();
+    const mirror = new Mirror({
+        doc,
+        schema: schema({
+            rows: schema.LoroList(
+                schema.LoroMap({
+                    id: schema.String(),
+                    items: schema.LoroList(schema.String(), undefined, {
+                        lazy: { index: [] },
+                    }),
+                }),
+            ),
+        }),
+    });
+    const before = mirror.getState().rows[0].items;
+    let error: unknown;
+    try {
+        mirror.setState((d) => {
+            Object.assign(d.rows[0], { items: ["new"] });
+        });
+    } catch (e) {
+        error = e;
+    }
+    expect(error).toBeDefined();
+    expect(mirror.getState().rows[0].items).toBe(before);
+    expect((row.get("items") as LoroList).toJSON()).toEqual(["old"]);
+});
+
+it("exposes lazy views in tree data", () => {
+    const doc = new LoroDoc();
+    const node = doc.getTree("tree").createNode();
+    node.data.setContainer("items", new LoroList()).push("old");
+    doc.commit();
+    const mirror = new Mirror({
+        doc,
+        schema: schema({
+            tree: schema.LoroTree(
+                schema.LoroMap({
+                    items: schema.LoroList(schema.String(), undefined, {
+                        lazy: { index: [] },
+                    }),
+                }),
+            ),
+        }),
+    });
+    expect(isLazyList(mirror.getState().tree[0].data.items)).toBe(true);
+});
+
+it("preserves local Ignore across mixed peer updates and deletes, including tree data", () => {
+    const doc = new LoroDoc();
+    const node = doc.getTree("tree").createNode();
+    node.data.set("name", "old");
+    node.data.set("cache", "doc");
+    doc.commit();
+    const m = new Mirror({
+        doc,
+        checkStateConsistency: true,
+        schema: schema({
+            tree: schema.LoroTree(
+                schema.LoroMap({
+                    name: schema.String(),
+                    cache: schema.Ignore(),
+                }),
+            ),
+        }),
+    });
+    m.setState((d) => {
+        d.tree[0].data.cache = "memory";
+    });
+    const peer = new LoroDoc();
+    peer.import(doc.export({ mode: "snapshot" }));
+    const map = peer.getContainerById(node.data.id) as LoroMap;
+    map.set("name", "peer");
+    map.set("cache", 42);
+    peer.commit();
+    doc.import(peer.export({ mode: "update" }));
+    expect(m.getState().tree[0].data).toMatchObject({
+        name: "peer",
+        cache: "memory",
+    });
+    map.delete("cache");
+    peer.commit();
+    doc.import(peer.export({ mode: "update" }));
+    expect(m.getState().tree[0].data.cache).toBe("memory");
+    m.setState((d) => {
+        d.tree[0].data.name = "local";
+    });
+    expect(node.data.get("name")).toBe("local");
+});
+
+it("keeps lazy instances across eager reordering and rejects tree replacement", async () => {
+    const doc = new LoroDoc();
+    const rows = doc.getMovableList("rows");
+    for (const id of ["a", "b"]) {
+        const row = rows.insertContainer(rows.length, new LoroMap());
+        row.set("id", id);
+        row.set("name", id);
+        row.setContainer("items", new LoroList()).push(id);
+    }
+    const node = doc.getTree("tree").createNode();
+    node.data.setContainer("items", new LoroList()).push("tree");
+    doc.commit();
+    const item = schema.LoroMap({
+        id: schema.String(),
+        name: schema.String(),
+        items: schema.LoroList(schema.String(), undefined, {
+            lazy: { index: [] },
+        }),
+    });
+    const m = new Mirror({
+        doc,
+        schema: schema({
+            rows: schema.LoroMovableList(item, (x) => x.id),
+            tree: schema.LoroTree(
+                schema.LoroMap({
+                    items: schema.LoroList(schema.String(), undefined, {
+                        lazy: { index: [] },
+                    }),
+                }),
+            ),
+        }),
+    });
+    const first = m.getState().rows[0].items;
+    m.setState((d) => {
+        d.rows.reverse();
+    });
+    expect(m.getState().rows[1].items).toBe(first);
+    m.setState((d) => {
+        d.rows[1].name = "changed";
+    });
+    expect(m.getState().rows[1].items).toBe(first);
+    const treeItems = m.getState().tree[0].data.items;
+    await treeItems.hydrate(0, 1);
+    expect(treeItems.get(0)).toBe("tree");
+    const before = doc.toJSON();
+    expect(() => {
+        m.setState((d) => {
+            Object.assign(d.tree[0].data, { items: ["bad"] });
+        });
+    }).toThrow(LazyListWriteError);
+    expect(doc.toJSON()).toEqual(before);
+});
+
+it("filters nested Ignore through all three initialization paths", () => {
+    for (const mode of ["tree", "deep", "legacy"]) {
+        const doc = new LoroDoc();
+        doc.getMap("session").set("cache", 42);
+        doc.getMap("session").set("name", "ok");
+        doc.commit();
+        if (mode !== "tree")
+            Object.defineProperty(doc, "toContainerTree", { value: undefined });
+        if (mode === "legacy")
+            Object.defineProperty(doc, "getDeepValueWithID", {
+                value: undefined,
+            });
+        const m = new Mirror({
+            doc,
+            schema: schema({
+                session: schema.LoroMap({
+                    name: schema.String(),
+                    cache: schema.Ignore(),
+                }),
+            }),
+        });
+        expect(m.getState().session).toEqual({ name: "ok" });
+    }
+});
+
+it("keeps tree lazy data after remote node insertion and streams", async () => {
+    const doc = new LoroDoc();
+    doc.getTree("tree");
+    const m = new Mirror({
+        doc,
+        schema: schema({
+            tree: schema.LoroTree(
+                schema.LoroMap({
+                    items: schema.LoroList(schema.String(), undefined, {
+                        lazy: { index: [] },
+                    }),
+                    cache: schema.Ignore(),
+                }),
+            ),
+        }),
+    });
+    const peer = new LoroDoc();
+    peer.import(doc.export({ mode: "snapshot" }));
+    const node = peer.getTree("tree").createNode();
+    const items = node.data.setContainer("items", new LoroList());
+    items.push("first");
+    node.data.set("cache", 42);
+    peer.commit();
+    doc.import(peer.export({ mode: "update" }));
+    const view = m.getState().tree[0].data.items;
+    expect(isLazyList(view)).toBe(true);
+    expect(m.getState().tree[0].data.cache).toBeUndefined();
+    await view.hydrate(0, 1);
+    expect(view.get(0)).toBe("first");
+    items.push("second");
+    peer.commit();
+    doc.import(peer.export({ mode: "update" }));
+    expect(view.length).toBe(2);
+});
+
+it("guards lazy fields under map records before any sibling is written", () => {
+    const doc = new LoroDoc();
+    const row = doc.getMap("rows").setContainer("a", new LoroMap());
+    row.set("name", "old");
+    row.setContainer("items", new LoroList()).push("old");
+    doc.commit();
+    const m = new Mirror({
+        doc,
+        schema: schema({
+            rows: schema.LoroMapRecord(
+                schema.LoroMap({
+                    name: schema.String(),
+                    items: schema.LoroList(schema.String(), undefined, {
+                        lazy: { index: [] },
+                    }),
+                }),
+            ),
+        }),
+    });
+    const before = doc.toJSON();
+    expect(() => {
+        m.setState((d) => {
+            d.rows.a.name = "new";
+            Object.assign(d.rows.a, { items: ["bad"] });
+        });
+    }).toThrow(LazyListWriteError);
+    expect(doc.toJSON()).toEqual(before);
+    expect(isLazyList(m.getState().rows.a.items)).toBe(true);
+});


### PR DESCRIPTION
Nested schema declarations currently behave differently depending on their location: scalar Ignore fields enter Mirror state through initial reads and parent Map events, while a lazy list inside an eager list can be overwritten by setState without an error. Tree node data also exposes ordinary arrays despite a lazy schema.

This follow-up to #96/#97/#98 makes those boundaries consistent:

- Skip Ignore fields in handle and bulk initialization, registration, and parent Map diffs. Mixed events still apply ordinary fields; existing in-memory Ignore values remain untouched.
- Check lazy view identity through eager lists, map records, and tree data before validation or writes. Match surviving list items by container ID and tree nodes by node ID so reordering remains allowed.
- Read typed Tree node maps through the schema-aware reader instead of materializing the tree with toJSON. Nested lazy fields now expose LazyList views at initialization and after remote node insertion.

The Ignore leakage predates #97; the lazy view issues were introduced with #96. No persisted document migration is performed. This PR is stacked on #98 (`perf/structured-read-state`), which already contains #96 and the main integration.

Validation: `pnpm check` passes (build, 632 tests across 60 files, lint: 19 warnings / 0 errors, typecheck). Fourteen real-Loro regression tests cover the original failures, mixed peer updates/deletion, all three initialization paths, MapRecord guards, reorder preservation, and Tree insertion/hydration. Uses loro-crdt 1.16.0. No browser or 3000-round end-to-end performance claim.

Follow-up: new rows without a container ID no longer match old rows by position. Newly initialized lazy map fields publish LazyList views instead of input arrays. Added head/middle/tail insertion coverage for both List and MovableList, including preservation of existing view identities and rejection of later replacements.
